### PR TITLE
test: stabilize gRPC stream and k6 liveness checks

### DIFF
--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -38,9 +39,9 @@ func (m *mockPushMetadataServer) Context() context.Context {
 	return context.Background()
 }
 
-func (m *mockPushMetadataServer) SetHeader(metadata.MD) error { return nil }
+func (m *mockPushMetadataServer) SetHeader(metadata.MD) error  { return nil }
 func (m *mockPushMetadataServer) SendHeader(metadata.MD) error { return nil }
-func (m *mockPushMetadataServer) SetTrailer(metadata.MD) { }
+func (m *mockPushMetadataServer) SetTrailer(metadata.MD)       {}
 
 func TestServer_PushMetadata(t *testing.T) {
 	manager := stream.NewManager()
@@ -48,7 +49,7 @@ func TestServer_PushMetadata(t *testing.T) {
 
 	// Добавляем тестовый стрим
 	manager.AddStream("cam_test", "rtsp://test", false, true, "tcp")
-	
+
 	st, exists := manager.GetStream("cam_test")
 	if !exists {
 		t.Fatal("stream not created")
@@ -99,17 +100,27 @@ func TestServer_PushMetadata(t *testing.T) {
 
 type mockStreamFramesServer struct {
 	grpc.ServerStream
-	ctx  context.Context
-	req  *pb.StreamRequest
-	resp []*pb.FrameResponse
+	ctx       context.Context
+	req       *pb.StreamRequest
+	resp      []*pb.FrameResponse
+	ready     chan struct{}
+	readyOnce sync.Once
+	sent      chan struct{}
+	sentOnce  sync.Once
 }
 
 func (m *mockStreamFramesServer) Send(resp *pb.FrameResponse) error {
 	m.resp = append(m.resp, resp)
+	if m.sent != nil {
+		m.sentOnce.Do(func() { close(m.sent) })
+	}
 	return nil
 }
 
 func (m *mockStreamFramesServer) Context() context.Context {
+	if m.ready != nil {
+		m.readyOnce.Do(func() { close(m.ready) })
+	}
 	if m.ctx == nil {
 		return context.Background()
 	}
@@ -132,10 +143,14 @@ func TestServer_StreamFrames(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	ready := make(chan struct{})
+	sent := make(chan struct{})
 
 	mockSrv := &mockStreamFramesServer{
-		ctx: ctx,
-		req: &pb.StreamRequest{CameraId: "cam_yolo"},
+		ctx:   ctx,
+		req:   &pb.StreamRequest{CameraId: "cam_yolo"},
+		ready: ready,
+		sent:  sent,
 	}
 
 	done := make(chan struct{})
@@ -148,6 +163,14 @@ func TestServer_StreamFrames(t *testing.T) {
 		close(done)
 	}()
 
+	// Wait until StreamFrames has created its RingBuffer reader and entered the
+	// request loop. Writing before this point makes the test race subscription.
+	select {
+	case <-ready:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for StreamFrames subscription")
+	}
+
 	// Пишем первый кадр
 	rb.Write(&buffer.Frame{
 		IsKeyFrame: true,
@@ -155,8 +178,11 @@ func TestServer_StreamFrames(t *testing.T) {
 		NALUs:      [][]byte{{0x05, 0x06}},
 	})
 
-	// Даем время на обработку
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-sent:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for StreamFrames response")
+	}
 
 	// Отменяем контекст, чтобы выйти из цикла в StreamFrames
 	cancel()

--- a/tests/performance/k6_load.js
+++ b/tests/performance/k6_load.js
@@ -14,12 +14,12 @@ export const options = {
 };
 
 export default function () {
-  // We hit the health endpoint and metrics endpoint to ensure the core is responsive
+  // We hit the registered liveness and metrics endpoints to ensure the core is responsive
   // In a real scenario, this would be the HLS playlist endpoint for an active stream
   
-  const res1 = http.get('http://localhost:8080/health');
+  const res1 = http.get('http://localhost:8080/livez');
   check(res1, {
-    'health status is 200': (r) => r.status === 200,
+    'liveness status is 200': (r) => r.status === 200,
   });
 
   const res2 = http.get('http://localhost:8080/metrics');


### PR DESCRIPTION
## Summary

- make `TestServer_StreamFrames` wait for subscription readiness and the first sent response instead of relying on a fixed sleep
- update the k6 liveness probe from the unregistered `/health` path to `/livez`

This is the first small follow-up from #27. It intentionally does not close the broader tracking issue.

## Why

`TestServer_StreamFrames` could publish its first frame before the streaming goroutine created its RingBuffer reader. That made the official test intermittently fail with `expected to receive frames, got 0`. The test now uses explicit one-shot synchronization for both subscription setup and response delivery.

The performance script requested `/health`, but the HTTP router registers `/livez` and `/readyz`. As a result, the liveness check could never validate the intended route.

## Impact

Production behavior is unchanged. The gRPC change is test-only, and the k6 change makes the existing performance workflow call the server's registered liveness endpoint.

## Validation

- `go test -count=100 -p=1 -run '^TestServer_StreamFrames$' ./internal/grpc`
- `go test -count=1 -race -p=1 -run '^TestServer_StreamFrames$' ./internal/grpc`
- `node --check tests/performance/k6_load.js`
- verified `/livez` is registered in `internal/api/router.go`
- `git diff --check`

