### PR TITLE
ci: harden CI/CD pipelines, pin versions and tighten security scanning

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version: '1.26.0'
 
       - name: Cache Go modules
         uses: actions/cache@v6

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version: '1.26.0'
 
       - name: Build mock Frontend for go:embed
         run: mkdir -p web/dist && touch web/dist/index.html
@@ -29,7 +29,7 @@ jobs:
           sleep 3 # Wait for server to start
 
       - name: Run k6 Load Test
-        run: docker run --rm --network host --user $(id -u):$(id -g) -v $(pwd):/app -w /app grafana/k6:latest run --summary-export=summary.json tests/performance/k6_load.js
+        run: docker run --rm --network host --user $(id -u):$(id -g) -v $(pwd):/app -w /app grafana/k6:1.8.1 run --summary-export=summary.json tests/performance/k6_load.js
 
       - name: Stop RUSEON Server
         run: pkill -f server || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version: '1.26.0'
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
@@ -36,7 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
 
@@ -44,7 +44,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run golangci-lint
         run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.12.2
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
           $(go env GOPATH)/bin/golangci-lint run --timeout=5m
 
       - name: Run Gosec Security Scanner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version: '1.26.0'
           cache: true
 
       - name: Verify Go Modules
@@ -37,13 +37,13 @@ jobs:
 
       - name: Run golangci-lint
         run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.12.2
           $(go env GOPATH)/bin/golangci-lint run --timeout=5m
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.28.0
         with:
-          args: -exclude-dir=pkg/grpc/pb -exclude=G104,G115,G122,G301,G304 ./...
+          args: -exclude-dir=pkg/grpc/pb ./...
 
       - name: Build Backend (Go)
         run: |
@@ -81,7 +81,7 @@ jobs:
           node-version: '24'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run OxLint
         run: npm run lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,27 +1,37 @@
-linters-settings:
-  staticcheck:
-    checks: ["all", "-SA1019"] # Ignore deprecated warnings (e.g. WriteH26x)
-
+version: "2"
 linters:
-  disable-all: false
   enable:
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - typecheck
     - bodyclose
+    - gocritic
     - gosec
     - prealloc
-    - gocritic
     - revive
-
-issues:
-  exclude-rules:
-    # Игнорируем неиспользуемый errcheck и gosec для тестов
-    - path: _test\.go
-      linters:
-        - errcheck
-        - gosec
-        - bodyclose
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - -SA1019
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - bodyclose
+          - errcheck
+          - gosec
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,7 @@ project_name: ruseon-core
 before:
   hooks:
     - go mod tidy
-    - npm --prefix ./web install
+    - npm --prefix ./web ci
     - npm --prefix ./web run build
 
 builds:
@@ -42,6 +42,12 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+
+checksum:
+  name_template: 'checksums.txt'
+
+sboms:
+  - artifacts: archive
 
 dockers:
   - image_templates:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,15 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o ruseon-core ./cmd/serv
 
 # Stage 3: Final Image
 FROM alpine:3.19
-RUN apk --no-cache add ca-certificates tzdata
+RUN apk --no-cache add ca-certificates tzdata && \
+    addgroup -g 10001 -S appgroup && \
+    adduser -u 10001 -S appuser -G appgroup
 WORKDIR /app
 COPY --from=backend-builder /app/ruseon-core /app/ruseon-core
 COPY --from=frontend-builder /app/web/dist /app/web/dist
-RUN mkdir -p /app/data /app/recordings /app/backups
+RUN mkdir -p /app/data /app/recordings /app/backups && \
+    chown -R appuser:appgroup /app
+USER appuser:appgroup
 EXPOSE 8080
 VOLUME ["/app/data", "/app/recordings", "/app/backups"]
 CMD ["/app/ruseon-core"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,8 +1,12 @@
 FROM alpine:3.19
-RUN apk --no-cache add ca-certificates tzdata
+RUN apk --no-cache add ca-certificates tzdata && \
+    addgroup -g 10001 -S appgroup && \
+    adduser -u 10001 -S appuser -G appgroup
 WORKDIR /app
 COPY ruseon-core /app/ruseon-core
-RUN mkdir -p /app/data /app/recordings /app/backups
+RUN mkdir -p /app/data /app/recordings /app/backups && \
+    chown -R appuser:appgroup /app
+USER appuser:appgroup
 EXPOSE 8080
 VOLUME ["/app/data", "/app/recordings", "/app/backups"]
 CMD ["/app/ruseon-core"]

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -469,7 +469,7 @@ func runAPIWorker(ctx context.Context, baseURL, token string, wg *sync.WaitGroup
 			}
 		} else {
 			data, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
+			_ = resp.Body.Close()
 
 			apiLatencySampler.Add(lat)
 
@@ -538,7 +538,7 @@ func runHLSViewer(ctx context.Context, baseURL string, camIDs []string, wg *sync
 			}
 
 			body, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			if resp.StatusCode != http.StatusOK {
 				cntHLSErr.Add(1)
 				continue
@@ -575,7 +575,7 @@ func runHLSViewer(ctx context.Context, baseURL string, camIDs []string, wg *sync
 					}
 
 					segData, _ := io.ReadAll(segResp.Body)
-					segResp.Body.Close()
+					_ = segResp.Body.Close()
 
 					if segResp.StatusCode == http.StatusOK {
 						hlsSegmentSampler.Add(time.Since(tSeg))
@@ -637,7 +637,8 @@ func runWebRTCViewer(ctx context.Context, baseURL string, camIDs []string, engin
 				return
 			}
 			cntWebRTCRTPPackets.Add(1)
-			cntWebRTCBytesRx.Add(uint64(n)) //nolint:gosec
+			// #nosec G115 -- packet size is non-negative
+			cntWebRTCBytesRx.Add(uint64(n))
 		}
 	})
 
@@ -870,7 +871,7 @@ func main() {
 
 	tmpRecDir := filepath.Join(os.TempDir(), fmt.Sprintf("ruseon_loadtest_%d", time.Now().UnixNano()))
 	if useRealDisk {
-		_ = os.MkdirAll(tmpRecDir, 0755)
+		_ = os.MkdirAll(tmpRecDir, 0750)
 		registry.RegisterBlobStore(localfs.NewLocalFS(tmpRecDir))
 		fmt.Printf("[setup] BlobStore : real disk (%s)\n", tmpRecDir)
 		defer os.RemoveAll(tmpRecDir)
@@ -1056,7 +1057,8 @@ func main() {
 		_ = filepath.Walk(tmpRecDir, func(_ string, info os.FileInfo, err error) error {
 			if err == nil && info != nil && !info.IsDir() {
 				diskFilesCreated++
-				diskBytesWritten += uint64(info.Size()) //nolint:gosec
+				// #nosec G115 -- file size is non-negative
+				diskBytesWritten += uint64(info.Size())
 			}
 			return nil
 		})
@@ -1262,7 +1264,7 @@ func freeAddr() (string, error) {
 		return "", err
 	}
 	addr := l.Addr().String()
-	l.Close()
+	_ = l.Close()
 	return addr, nil
 }
 

--- a/cmd/loadtest/stats.go
+++ b/cmd/loadtest/stats.go
@@ -36,7 +36,8 @@ func NewLatencySampler(expectedSamples int) *LatencySampler {
 // Add добавляет замер задержки.
 func (s *LatencySampler) Add(d time.Duration) {
 	ms := float64(d.Nanoseconds()) / 1e6
-	us := uint64(d.Microseconds()) //nolint:gosec
+	// #nosec G115 -- non-negative duration
+	us := uint64(d.Microseconds())
 
 	s.count.Add(1)
 	s.sumMs.Add(us)

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -244,7 +244,8 @@ func (h *Handler) GetCameras(c *gin.Context) {
 			if stats != nil {
 				s := stats.GetStats()
 				state = s.State
-				uptime = uint64(s.Uptime) //nolint:gosec
+				// #nosec G115 -- uptime in seconds is non-negative
+				uptime = uint64(s.Uptime)
 				bytesReceived = s.BytesReceived
 				bytesSent = s.BytesSent
 				frames = s.Frames

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -235,7 +235,7 @@ func (h *Handler) GetCameras(c *gin.Context) {
 		for _, cam := range cams {
 			stats := streamMap[cam.ID]
 
-			var state models.CameraState = models.StateOffline
+			state := models.StateOffline
 			var uptime, bytesReceived, bytesSent, frames, keyFrames, reconnects uint64
 			var lastFrameTime, lastKeyTime int64
 			var bitrate float64

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -42,7 +42,7 @@ func (h *Handler) GetModel(c *gin.Context) {
 	}
 
 	modelsDir := filepath.Join("data", "models")
-	_ = os.MkdirAll(modelsDir, 0755)
+	_ = os.MkdirAll(modelsDir, 0750)
 	modelPath := filepath.Join(modelsDir, filename)
 
 	// 1. Fast path: Serve from local disk cache if already downloaded (> 4MB)
@@ -94,7 +94,7 @@ func (h *Handler) GetModel(c *gin.Context) {
 		log.Info().Str("filename", filename).Str("url", finalURL).Msg("Saving AI model to local disk cache...")
 
 		tmpFile := modelPath + ".tmp"
-		f, err := os.Create(tmpFile)
+		f, err := os.Create(filepath.Clean(tmpFile)) // #nosec G304
 		if err != nil {
 			return nil, fmt.Errorf("failed to create local model file: %w", err)
 		}

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -84,17 +84,20 @@ func (h *Handler) StreamWS(c *gin.Context) {
 	headerBuf[1] = codecType
 	offset := 2
 
-	binary.BigEndian.PutUint16(headerBuf[offset:], uint16(len(vps))) //nolint:gosec // validated <= 0xFFFF
+	// #nosec G115 -- parameter set length is validated <= 0xFFFF
+	binary.BigEndian.PutUint16(headerBuf[offset:], uint16(len(vps)))
 	offset += 2
 	copy(headerBuf[offset:], vps)
 	offset += len(vps)
 
-	binary.BigEndian.PutUint16(headerBuf[offset:], uint16(len(sps))) //nolint:gosec // validated <= 0xFFFF
+	// #nosec G115 -- parameter set length is validated <= 0xFFFF
+	binary.BigEndian.PutUint16(headerBuf[offset:], uint16(len(sps)))
 	offset += 2
 	copy(headerBuf[offset:], sps)
 	offset += len(sps)
 
-	binary.BigEndian.PutUint16(headerBuf[offset:], uint16(len(pps))) //nolint:gosec // validated <= 0xFFFF
+	// #nosec G115 -- parameter set length is validated <= 0xFFFF
+	binary.BigEndian.PutUint16(headerBuf[offset:], uint16(len(pps)))
 	offset += 2
 	copy(headerBuf[offset:], pps)
 
@@ -187,7 +190,8 @@ func (h *Handler) StreamWS(c *gin.Context) {
 			if tsMicro < 0 {
 				tsMicro = 0
 			}
-			binary.BigEndian.PutUint64(packetBuf[2:10], uint64(tsMicro)) //nolint:gosec // tsMicro >= 0
+			// #nosec G115 -- tsMicro is clamped >= 0
+			binary.BigEndian.PutUint64(packetBuf[2:10], uint64(tsMicro))
 
 			writePos := 10
 			for _, nalu := range frame.NALUs {
@@ -204,6 +208,7 @@ func (h *Handler) StreamWS(c *gin.Context) {
 				return
 			}
 
+			// #nosec G115 -- packetBuf length is non-negative
 			st.AddBytesSent(uint64(len(packetBuf)))
 		}
 	}

--- a/internal/archive/hls.go
+++ b/internal/archive/hls.go
@@ -103,7 +103,7 @@ func getFileIndex(path string) (*FileIndex, error) {
 				_, _ = io.ReadFull(f, mdatData)
 				
 				// Парсим Part
-				var combined []byte
+				combined := make([]byte, 0, len(moofData)+len(mdatData))
 				combined = append(combined, moofData...)
 				combined = append(combined, mdatData...)
 				
@@ -160,13 +160,13 @@ func GenerateHLSPlaylist(recordDir, cameraID, filename string) (string, error) {
 			maxDurSec = dur
 		}
 	}
-	buf.WriteString(fmt.Sprintf("#EXT-X-TARGETDURATION:%d\n", maxDurSec))
+	fmt.Fprintf(&buf, "#EXT-X-TARGETDURATION:%d\n", maxDurSec)
 	buf.WriteString("#EXT-X-MEDIA-SEQUENCE:0\n")
 
 	for i, p := range idx.Parts {
 		durSec := float64(p.Duration) / 90000.0
-		buf.WriteString(fmt.Sprintf("#EXTINF:%.3f,\n", durSec))
-		buf.WriteString(fmt.Sprintf("segment.ts?file=%s&seq=%d\n", filename, i))
+		fmt.Fprintf(&buf, "#EXTINF:%.3f,\n", durSec)
+		fmt.Fprintf(&buf, "segment.ts?file=%s&seq=%d\n", filename, i)
 	}
 	
 	buf.WriteString("#EXT-X-ENDLIST\n")
@@ -218,7 +218,7 @@ func GenerateHLSSegment(recordDir, cameraID, filename string, seq int) ([]byte, 
 	mdatData := make([]byte, mdatSize)
 	_, _ = io.ReadFull(f, mdatData)
 	
-	var combined []byte
+	combined := make([]byte, 0, len(moofData)+len(mdatData))
 	combined = append(combined, moofData...)
 	combined = append(combined, mdatData...)
 	

--- a/internal/archive/hls.go
+++ b/internal/archive/hls.go
@@ -250,7 +250,7 @@ func GenerateHLSSegment(recordDir, cameraID, filename string, seq int) ([]byte, 
 	tsWriter = mpegts.NewWriter(outBuf, []*mpegts.Track{tsTrack})
 
 	// 4. Перепаковываем NALU в TS
-	pts := int64(part.Tracks[0].BaseTime) //nolint:gosec
+	pts := int64(part.Tracks[0].BaseTime) // #nosec G115
 	for _, sample := range part.Tracks[0].Samples {
 		isKeyFrame := !sample.IsNonSyncSample
 		

--- a/internal/backup/worker.go
+++ b/internal/backup/worker.go
@@ -23,7 +23,7 @@ type Worker struct {
 
 // NewWorker создает новый воркер для бэкапов.
 func NewWorker(store registry.StateStore, backupDir string, interval time.Duration, retentionDays int) *Worker {
-	if err := os.MkdirAll(backupDir, 0755); err != nil {
+	if err := os.MkdirAll(backupDir, 0750); err != nil {
 		log.Error().Err(err).Msg("Failed to create backup directory")
 	}
 	return &Worker{
@@ -62,7 +62,7 @@ func (w *Worker) Run(ctx context.Context) {
 func (w *Worker) doBackup() {
 	filename := filepath.Join(w.backupDir, fmt.Sprintf("badger_backup_%s.bak", time.Now().Format("2006-01-02_15-04-05")))
 	
-	f, err := os.Create(filename)
+	f, err := os.Create(filepath.Clean(filename)) // #nosec G304
 	if err != nil {
 		log.Error().Err(err).Str("file", filename).Msg("Failed to create backup file")
 		return

--- a/internal/buffer/ring.go
+++ b/internal/buffer/ring.go
@@ -50,7 +50,7 @@ func (rb *RingBuffer) SetCameraID(id string) {
 func (rb *RingBuffer) Write(f *Frame) {
 	// 1. Сохраняем в кольцевой буфер (для истории новым клиентам)
 	rb.mu.Lock()
-	//nolint:gosec // capacity is always positive
+	// #nosec G115 -- rb.capacity is always positive
 	idx := rb.head % uint64(rb.capacity)
 	rb.frames[idx] = f
 	rb.head++
@@ -130,13 +130,13 @@ func (rb *RingBuffer) Subscribe() *Reader {
 	startIdx := rb.head
 	found := false
 	for i := 0; i < rb.capacity; i++ {
-		//nolint:gosec // i is always positive
+		// #nosec G115 -- i is always non-negative
 		step := uint64(i + 1)
 		if rb.head < step {
 			break
 		}
 		idx := rb.head - step
-		//nolint:gosec // capacity is always positive
+		// #nosec G115 -- rb.capacity is always positive
 		frame := rb.frames[idx%uint64(rb.capacity)]
 		if frame != nil && frame.IsKeyFrame {
 			startIdx = idx
@@ -148,7 +148,7 @@ func (rb *RingBuffer) Subscribe() *Reader {
 	// Закидываем исторические кадры в канал (начиная с найденного I-Frame)
 	if found {
 		for i := startIdx; i < rb.head; i++ {
-			//nolint:gosec // capacity is always positive
+			// #nosec G115 -- rb.capacity is always positive
 			f := rb.frames[i%uint64(rb.capacity)]
 			if f != nil {
 				r.C <- f

--- a/internal/hls/muxer.go
+++ b/internal/hls/muxer.go
@@ -119,11 +119,7 @@ func (m *Muxer) run() {
 	// Читаем параметры кодека из буфера
 	vps, sps, pps := m.ringBuffer.GetParams()
 
-	for {
-		if m.ctx.Err() != nil {
-			break
-		}
-
+	for m.ctx.Err() == nil {
 		if sps == nil || pps == nil {
 			vps, sps, pps = m.ringBuffer.GetParams()
 		}
@@ -145,7 +141,7 @@ func (m *Muxer) run() {
 			segmentStartPts := int64(segmentStart * 90000 / time.Second)
 			var vttBuf bytes.Buffer
 			vttBuf.WriteString("WEBVTT\n")
-			vttBuf.WriteString(fmt.Sprintf("X-TIMESTAMP-MAP=MPEGTS:%d,LOCAL:00:00:00.000\n\n", segmentStartPts))
+			fmt.Fprintf(&vttBuf, "X-TIMESTAMP-MAP=MPEGTS:%d,LOCAL:00:00:00.000\n\n", segmentStartPts)
 
 			for _, req := range meta {
 				var localPts int64
@@ -179,7 +175,7 @@ func (m *Muxer) run() {
 					hrEnd++
 				}
 
-				vttBuf.WriteString(fmt.Sprintf("%02d:%02d:%02d.%03d --> %02d:%02d:%02d.%03d\n", hr, minutes, sec, ms, hrEnd, minEnd, secEnd, msEnd))
+				fmt.Fprintf(&vttBuf, "%02d:%02d:%02d.%03d --> %02d:%02d:%02d.%03d\n", hr, minutes, sec, ms, hrEnd, minEnd, secEnd, msEnd)
 				data, _ := json.Marshal(req)
 				vttBuf.Write(data)
 				vttBuf.WriteString("\n\n")

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -61,7 +61,7 @@ func (r *Recorder) run() {
 
 	closeAndRename := func() {
 		if file != nil {
-			file.Close()
+			_ = file.Close()
 			recordEndTime := time.Now()
 			finalFilename := filepath.Join(filepath.Dir(currentFilename), fmt.Sprintf("%s_to_%s.mp4", recordStartTime.Format("2006-01-02_15-04-05"), recordEndTime.Format("15-04-05")))
 			_ = registry.CurrentBlobStore.Rename(currentFilename, finalFilename)
@@ -136,7 +136,7 @@ func (r *Recorder) run() {
 			// Считаем примерный объем записанного в байтах по размеру сэмплов
 			var size uint32
 			for _, s := range partSamples {
-				size += uint32(len(s.Payload)) //nolint:gosec
+				size += uint32(len(s.Payload)) // #nosec G115 -- payload length fits within uint32
 			}
 			metrics.DiskWriteBytesTotal.WithLabelValues(r.streamID).Add(float64(size))
 
@@ -225,7 +225,7 @@ func (r *Recorder) run() {
 
 		// Устанавливаем Duration для предыдущего сэмпла
 		if pendingSample != nil {
-			pendingSample.Duration = uint32(currentPts - lastPts) //nolint:gosec
+			pendingSample.Duration = uint32(currentPts - lastPts) // #nosec G115 -- duration fits within uint32
 			partSamples = append(partSamples, pendingSample)
 		}
 
@@ -265,7 +265,7 @@ func (r *Recorder) run() {
 			// Считаем примерный объем записанного в байтах по размеру сэмплов
 			var size uint32
 			for _, s := range partSamples {
-				size += uint32(len(s.Payload)) //nolint:gosec
+				size += uint32(len(s.Payload)) // #nosec G115 -- payload length fits within uint32
 			}
 			metrics.DiskWriteBytesTotal.WithLabelValues(r.streamID).Add(float64(size))
 
@@ -276,7 +276,7 @@ func (r *Recorder) run() {
 
 			partSamples = partSamples[:0]
 			seq++
-			partStartBaseTime = uint64(currentPts) //nolint:gosec
+			partStartBaseTime = uint64(currentPts) // #nosec G115 -- currentPts is non-negative
 		}
 	}
 ExitLoop:

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -151,11 +151,7 @@ func (s *Stream) run() {
 	}
 
 	log.Info().Str("id", s.ID).Msg("Starting stream processing")
-	for {
-		if s.ctx.Err() != nil {
-			break
-		}
-
+	for s.ctx.Err() == nil {
 		log.Info().Str("id", s.ID).Str("url", s.URL).Msg("Connecting to RTSP")
 
 		s.rtspMu.Lock()

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -168,7 +168,8 @@ func (s *Stream) run() {
 			for _, n := range nalus {
 				size += len(n)
 			}
-			s.bytesReceived.Add(uint64(size)) //nolint:gosec
+			// #nosec G115 -- size of frame payload is non-negative
+			s.bytesReceived.Add(uint64(size))
 			s.metricNetRxBytes.Add(float64(size))
 			
 			s.lastFrameTime.Store(time.Now().Unix())

--- a/internal/webrtc/muxer.go
+++ b/internal/webrtc/muxer.go
@@ -84,13 +84,13 @@ func (h *WHEPHandler) HandleOffer(_ context.Context, offerSDP string) (string, e
 
 	videoTrack, err := webrtc.NewTrackLocalStaticSample(webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264}, "video", "pion")
 	if err != nil {
-		pc.Close()
+		_ = pc.Close()
 		return "", err
 	}
 
 	rtpSender, err := pc.AddTrack(videoTrack)
 	if err != nil {
-		pc.Close()
+		_ = pc.Close()
 		return "", err
 	}
 
@@ -114,7 +114,7 @@ func (h *WHEPHandler) HandleOffer(_ context.Context, offerSDP string) (string, e
 		if connectionState == webrtc.ICEConnectionStateClosed ||
 			connectionState == webrtc.ICEConnectionStateFailed ||
 			connectionState == webrtc.ICEConnectionStateDisconnected {
-			pc.Close()
+			_ = pc.Close()
 			cancelPump()
 		}
 	})
@@ -147,20 +147,20 @@ func (h *WHEPHandler) HandleOffer(_ context.Context, offerSDP string) (string, e
 	})
 
 	if err := pc.SetRemoteDescription(offer); err != nil {
-		pc.Close()
+		_ = pc.Close()
 		return "", err
 	}
 
 	answer, err := pc.CreateAnswer(nil)
 	if err != nil {
-		pc.Close()
+		_ = pc.Close()
 		return "", err
 	}
 
 	gatherComplete := webrtc.GatheringCompletePromise(pc)
 
 	if err := pc.SetLocalDescription(answer); err != nil {
-		pc.Close()
+		_ = pc.Close()
 		return "", err
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
@@ -116,7 +117,7 @@ type CameraConfig struct {
 
 // Load считывает конфигурацию из файла.
 func Load(path string) (*Config, error) {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Clean(path)) // #nosec G304
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +153,7 @@ func Load(path string) (*Config, error) {
 
 // Save сохраняет текущую конфигурацию в файл.
 func (c *Config) Save(path string) error {
-	file, err := os.Create(path)
+	file, err := os.Create(filepath.Clean(path)) // #nosec G304
 	if err != nil {
 		return err
 	}

--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -81,9 +81,8 @@ func (b *EventBus) Publish(topic string, cameraID string, data any) {
 	}
 
 	h := fnv.New32a()
-	h.Write([]byte(key))
-	//nolint:gosec // len(b.workers) is always positive, safe to convert
-	workerID := int(h.Sum32() % uint32(len(b.workers)))
+	_, _ = h.Write([]byte(key))
+	workerID := int(h.Sum32() % uint32(len(b.workers))) // #nosec G115
 
 	// Non-blocking send (Drop-Newest)
 	select {

--- a/pkg/storage/localfs/file_linux.go
+++ b/pkg/storage/localfs/file_linux.go
@@ -32,7 +32,7 @@ func (fw *FileWrapper) Write(p []byte) (n int, err error) {
 	fw.offset += int64(n)
 
 	if fw.offset-fw.lastSync >= fw.chunkSize {
-		fd := int(fw.File.Fd())
+		fd := int(fw.Fd())
 
 		// Сначала дожидаемся и очищаем предыдущий чанк (N-2)
 		if fw.lastSync > fw.lastDrop {
@@ -51,15 +51,15 @@ func (fw *FileWrapper) Write(p []byte) (n int, err error) {
 
 func (fw *FileWrapper) Close() error {
 	remain := fw.offset - fw.lastDrop
-	fd := int(fw.File.Fd())
+	fd := int(fw.Fd())
 
 	if remain > 0 {
 		_ = unix.SyncFileRange(fd, fw.lastDrop, remain, unix.SYNC_FILE_RANGE_WAIT_BEFORE|unix.SYNC_FILE_RANGE_WRITE|unix.SYNC_FILE_RANGE_WAIT_AFTER)
 	}
 
 	// Фиксируем метаданные (размер файла) через полноценный fsync
-	if err := fw.File.Sync(); err != nil {
-		fw.File.Close()
+	if err := fw.Sync(); err != nil {
+		_ = fw.File.Close()
 		return err
 	}
 

--- a/pkg/storage/localfs/localfs.go
+++ b/pkg/storage/localfs/localfs.go
@@ -43,10 +43,10 @@ func (l *LocalFS) Write(path string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(fp), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(fp), 0750); err != nil {
 		return err
 	}
-	return os.WriteFile(fp, data, 0600)
+	return os.WriteFile(fp, data, 0600) // #nosec G304
 }
 
 func (l *LocalFS) Read(path string) ([]byte, error) {
@@ -54,7 +54,7 @@ func (l *LocalFS) Read(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return os.ReadFile(fp)
+	return os.ReadFile(fp) // #nosec G304
 }
 
 func (l *LocalFS) Delete(path string) error {
@@ -86,10 +86,10 @@ func (l *LocalFS) Create(path string) (registry.WriteSeekCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(filepath.Dir(fp), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(fp), 0750); err != nil {
 		return nil, err
 	}
-	f, err := os.Create(fp)
+	f, err := os.Create(fp) // #nosec G304
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (l *LocalFS) Open(path string) (io.ReadSeekCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return os.Open(fp)
+	return os.Open(fp) // #nosec G304
 }
 
 func (l *LocalFS) MkdirAll(path string) error {
@@ -109,7 +109,7 @@ func (l *LocalFS) MkdirAll(path string) error {
 	if err != nil {
 		return err
 	}
-	return os.MkdirAll(fp, 0755)
+	return os.MkdirAll(fp, 0750)
 }
 
 func (l *LocalFS) Rename(oldPath, newPath string) error {


### PR DESCRIPTION
## Summary

This pull request addresses the **CI and release assurance** workstream from #27 and closes #29:

- **Version Pinning**:
  - Pinned Go patch release (`1.26.0`) across all workflows.
  - Pinned `golangci-lint` to `v2.12.2`.
  - Pinned `gosec` to `v2.28.0`.
  - Pinned k6 load test Docker image to `grafana/k6:1.8.1`.
  - Pinned `GoReleaser` to `~> v2`.
- **Security Scanner Hardening**:
  - Removed broad `-exclude=G104,G115,G122,G301,G304` arguments from CI `gosec` step.
  - Resolved and annotated real findings in Go code with justified inline `// #nosec` directives (G104, G115, G301, G304).
- **Deterministic Builds & Supply Chain**:
  - Enforced `npm ci` in CI frontend checks and GoReleaser hooks.
  - Added SBOM generation (Syft) and checksums to `.goreleaser.yaml`.
  - Configured non-root container runtime (`appuser:10001`) in `Dockerfile` and `Dockerfile.goreleaser`.

## Validation

- `golangci-lint run ./...` -> 0 lint errors
- `gosec -exclude-dir=pkg/grpc/pb ./...` -> 0 issues (28 nosec)
- `go test -v ./...` -> all unit & E2E tests pass

Closes #29
Relates to #27