### PR TITLE
fix(stream): preserve invariant between durable camera configuration and runtime stream manager

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -320,6 +320,7 @@ func (h *Handler) GetCameras(c *gin.Context) {
 // @Param camera body config.CameraConfig true "Camera Configuration"
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
+// @Failure 409 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /api/cameras [post]
 func (h *Handler) AddCamera(c *gin.Context) {
@@ -329,18 +330,25 @@ func (h *Handler) AddCamera(c *gin.Context) {
 		return
 	}
 
+	cam.ID = strings.TrimSpace(cam.ID)
+	if cam.ID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Camera ID cannot be empty"})
+		return
+	}
+
+	// Проверяем, не существует ли уже камера с таким ID в хранилище
+	if existing, _ := h.store.GetCamera(cam.ID); existing != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("Camera with ID '%s' already exists", cam.ID)})
+		return
+	}
+
 	if err := h.store.SaveCamera(&cam); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save camera to DB"})
 		return
 	}
 
-	// Запускаем поток, если он не отключен
-	if !cam.Disabled {
-		if err := h.manager.AddStream(cam.ID, cam.URL, cam.Record, cam.LazyHLS, cam.Transport); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-	}
+	// Атомарно синхронизируем рантайм-менеджер потоков
+	h.manager.UpsertStream(cam.ID, cam.URL, cam.Record, cam.LazyHLS, cam.Transport, cam.Disabled)
 
 	log.Info().Str("audit", "true").Str("action", "camera_added").Str("camera_id", cam.ID).Str("user", c.GetString("username")).Msg("Camera added")
 	h.InvalidateCamerasCache()
@@ -353,17 +361,24 @@ func (h *Handler) AddCamera(c *gin.Context) {
 // @Produce json
 // @Param id path string true "Camera ID"
 // @Success 200 {object} map[string]string
+// @Failure 404 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /api/cameras/{id} [delete]
 func (h *Handler) DeleteCamera(c *gin.Context) {
 	id := c.Param("id")
+
+	// Проверяем, существует ли камера в хранилище
+	if _, err := h.store.GetCamera(id); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("Camera '%s' not found", id)})
+		return
+	}
 
 	if err := h.store.DeleteCamera(id); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete camera"})
 		return
 	}
 
-	// Останавливаем поток
+	// Останавливаем поток и удаляем из менеджера
 	h.manager.RemoveStream(id)
 
 	log.Info().Str("audit", "true").Str("action", "camera_deleted").Str("camera_id", id).Str("user", c.GetString("username")).Msg("Camera deleted")
@@ -380,6 +395,7 @@ func (h *Handler) DeleteCamera(c *gin.Context) {
 // @Param camera body config.CameraConfig true "Updated Camera Configuration"
 // @Success 200 {object} map[string]string
 // @Failure 400 {object} map[string]string
+// @Failure 404 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /api/cameras/{id} [put]
 func (h *Handler) EditCamera(c *gin.Context) {
@@ -389,6 +405,9 @@ func (h *Handler) EditCamera(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid input"})
 		return
 	}
+
+	// Гарантируем соответствие ID в URL и теле запроса
+	req.ID = id
 
 	err := h.store.UpdateCameraTx(id, func(cam *config.CameraConfig) bool {
 		cam.URL = req.URL
@@ -400,6 +419,7 @@ func (h *Handler) EditCamera(c *gin.Context) {
 		cam.SimICCID = req.SimICCID
 		cam.LazyHLS = req.LazyHLS
 		cam.TokenAuth = req.TokenAuth
+		cam.Transport = req.Transport
 
 		// Отслеживание изменения статуса записи
 		if cam.Record != req.Record {
@@ -435,15 +455,12 @@ func (h *Handler) EditCamera(c *gin.Context) {
 	})
 
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update camera"})
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("Camera '%s' not found or failed to update", id)})
 		return
 	}
 
-	// Перезапускаем поток если он включен
-	h.manager.RemoveStream(id)
-	if !req.Disabled {
-		_ = h.manager.AddStream(req.ID, req.URL, req.Record, req.LazyHLS, req.Transport)
-	}
+	// Атомарно обновляем рантайм-поток
+	h.manager.UpsertStream(id, req.URL, req.Record, req.LazyHLS, req.Transport, req.Disabled)
 
 	log.Info().Str("audit", "true").Str("action", "camera_edited").Str("camera_id", id).Str("user", c.GetString("username")).Msg("Camera edited")
 	h.InvalidateCamerasCache()

--- a/internal/api/handler_camera_test.go
+++ b/internal/api/handler_camera_test.go
@@ -1,0 +1,185 @@
+﻿package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RUSEGAL/ruseon-core/pkg/config"
+)
+
+func TestHandler_CameraLifecycleInvariants(t *testing.T) {
+	router, handler, store := setupTestRouter(t)
+	defer store.Close()
+
+	router.GET("/api/cameras", handler.GetCameras)
+	router.POST("/api/cameras", handler.AddCamera)
+	router.PUT("/api/cameras/:id", handler.EditCamera)
+	router.DELETE("/api/cameras/:id", handler.DeleteCamera)
+
+	// 1. Попытка добавить камеру с пустым ID -> 400 Bad Request
+	emptyIDCam := []byte(`{"id":"","url":"rtsp://127.0.0.1:8554/cam1","disabled":true}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/cameras", bytes.NewBuffer(emptyIDCam))
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty camera ID, got %d", w.Code)
+	}
+
+	// 2. Успешное добавление камеры -> 200 OK
+	validCam := []byte(`{"id":"cam1","url":"rtsp://127.0.0.1:8554/cam1","disabled":false,"record":false,"lazyHLS":true}`)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/cameras", bytes.NewBuffer(validCam))
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for valid camera, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Проверяем что стрим зарегистрирован в рантайме
+	if !handler.manager.HasStream("cam1") {
+		t.Fatalf("expected stream manager to have cam1 running")
+	}
+
+	// 3. Попытка добавить дубликат ID -> 409 Conflict
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/cameras", bytes.NewBuffer(validCam))
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict when adding duplicate camera, got %d", w.Code)
+	}
+
+	// 4. Редактирование несуществующей камеры -> 404 Not Found
+	nonExistentEdit := []byte(`{"url":"rtsp://127.0.0.1:8554/cam_none","disabled":true}`)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("PUT", "/api/cameras/cam_none", bytes.NewBuffer(nonExistentEdit))
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-existent camera edit, got %d", w.Code)
+	}
+
+	// 5. Отключение камеры через Edit (disabled=true) -> 200 OK
+	disableEdit := []byte(`{"url":"rtsp://127.0.0.1:8554/cam1","disabled":true,"disableReason":"technical"}`)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("PUT", "/api/cameras/cam1", bytes.NewBuffer(disableEdit))
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for disable edit, got %d", w.Code)
+	}
+
+	// Проверяем что поток остановлен в менеджере
+	if handler.manager.HasStream("cam1") {
+		t.Fatalf("expected cam1 stream to be stopped when disabled")
+	}
+
+	// Проверяем статус в БД
+	storedCam, err := store.GetCamera("cam1")
+	if err != nil || storedCam == nil {
+		t.Fatalf("expected cam1 to exist in store: %v", err)
+	}
+	if !storedCam.Disabled || storedCam.DisableReason != "technical" {
+		t.Fatalf("expected stored cam1 to be disabled with reason 'technical'")
+	}
+
+	// 6. Повторное включение камеры (disabled=false) -> 200 OK
+	enableEdit := []byte(`{"url":"rtsp://127.0.0.1:8554/cam1_new","disabled":false,"lazyHLS":true}`)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("PUT", "/api/cameras/cam1", bytes.NewBuffer(enableEdit))
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for enable edit, got %d", w.Code)
+	}
+
+	if !handler.manager.HasStream("cam1") {
+		t.Fatalf("expected cam1 stream to be restarted in manager after enabling")
+	}
+	st, _ := handler.manager.GetStream("cam1")
+	if st.URL != "rtsp://127.0.0.1:8554/cam1_new" {
+		t.Fatalf("expected stream URL to be updated to cam1_new, got %s", st.URL)
+	}
+
+	// 7. Удаление несуществующей камеры -> 404 Not Found
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("DELETE", "/api/cameras/cam_none", nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-existent camera delete, got %d", w.Code)
+	}
+
+	// 8. Успешное удаление существующей камеры -> 200 OK
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("DELETE", "/api/cameras/cam1", nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for camera delete, got %d", w.Code)
+	}
+
+	// Проверяем что поток удален из менеджера и БД
+	if handler.manager.HasStream("cam1") {
+		t.Fatalf("expected cam1 stream to be removed from manager after deletion")
+	}
+	if _, err := store.GetCamera("cam1"); err == nil {
+		t.Fatalf("expected cam1 to be deleted from store")
+	}
+}
+
+func TestHandler_GetCameras_ReflectsDynamicState(t *testing.T) {
+	router, handler, store := setupTestRouter(t)
+	defer store.Close()
+
+	router.GET("/api/cameras", handler.GetCameras)
+	router.POST("/api/cameras", handler.AddCamera)
+
+	// Добавляем 2 камеры: одну активную, одну отключенную
+	cam1 := &config.CameraConfig{ID: "cam_active", URL: "rtsp://test/active", Disabled: false, LazyHLS: true}
+	cam2 := &config.CameraConfig{ID: "cam_disabled", URL: "rtsp://test/disabled", Disabled: true}
+
+	body1, _ := json.Marshal(cam1)
+	w1 := httptest.NewRecorder()
+	req1, _ := http.NewRequest("POST", "/api/cameras", bytes.NewBuffer(body1))
+	router.ServeHTTP(w1, req1)
+
+	body2, _ := json.Marshal(cam2)
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest("POST", "/api/cameras", bytes.NewBuffer(body2))
+	router.ServeHTTP(w2, req2)
+
+	// Получаем список камер через GET
+	wGet := httptest.NewRecorder()
+	reqGet, _ := http.NewRequest("GET", "/api/cameras", nil)
+	router.ServeHTTP(wGet, reqGet)
+
+	if wGet.Code != http.StatusOK {
+		t.Fatalf("expected 200 for GetCameras, got %d", wGet.Code)
+	}
+
+	var cams []CameraInfo
+	if err := json.Unmarshal(wGet.Body.Bytes(), &cams); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(cams) != 2 {
+		t.Fatalf("expected 2 cameras, got %d", len(cams))
+	}
+
+	var foundActive, foundDisabled bool
+	for _, c := range cams {
+		if c.ID == "cam_active" {
+			foundActive = true
+			if c.Disabled {
+				t.Errorf("cam_active should not be marked disabled")
+			}
+		}
+		if c.ID == "cam_disabled" {
+			foundDisabled = true
+			if !c.Disabled {
+				t.Errorf("cam_disabled should be marked disabled")
+			}
+		}
+	}
+
+	if !foundActive || !foundDisabled {
+		t.Errorf("expected to find both active and disabled cameras in list")
+	}
+}

--- a/internal/stream/manager.go
+++ b/internal/stream/manager.go
@@ -70,6 +70,46 @@ func (m *Manager) GetStreams() []*Stream {
 	return result
 }
 
+// HasStream проверяет, зарегистрирован ли поток в менеджере.
+func (m *Manager) HasStream(id string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, exists := m.streams[id]
+	return exists
+}
+
+// UpsertStream атомарно создает, обновляет или останавливает поток в зависимости от конфигурации.
+// Если поток отключен (disabled=true), он останавливается и удаляется из менеджера.
+// Если поток включен (disabled=false), он создается или обновляется при изменении параметров.
+func (m *Manager) UpsertStream(id, url string, record bool, lazyHLS bool, transport string, disabled bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	existing, exists := m.streams[id]
+	if disabled {
+		if exists {
+			existing.Stop()
+			delete(m.streams, id)
+			log.Info().Str("id", id).Msg("Stream stopped and removed (disabled)")
+		}
+		return
+	}
+
+	if exists {
+		if existing.MatchesConfig(url, record, lazyHLS, transport) {
+			// Параметры стрима не изменились, оставляем работать без прерывания
+			return
+		}
+		// Параметры изменились, пересоздаем стрим
+		existing.Stop()
+		delete(m.streams, id)
+		log.Info().Str("id", id).Msg("Stream parameters changed, recreating stream")
+	}
+
+	st := NewStream(id, url, record, lazyHLS, transport)
+	m.streams[id] = st
+}
+
 // SyncWithStorage синхронизирует состояние потоков с базой.
 func (m *Manager) SyncWithStorage(store registry.StateStore) error {
 	log.Info().Msg("Syncing stream manager with storage...")
@@ -82,20 +122,30 @@ func (m *Manager) SyncWithStorage(store registry.StateStore) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	
-	// 1. Остановка всех текущих потоков
-	for id, st := range m.streams {
-		st.Stop()
-		delete(m.streams, id)
-	}
-	
-	// 2. Инициализация новых потоков
+	activeIDs := make(map[string]struct{}, len(cams))
 	for _, cam := range cams {
 		if !cam.Disabled {
-			st := NewStream(cam.ID, cam.URL, cam.Record, cam.LazyHLS, cam.Transport)
-			m.streams[cam.ID] = st
-			log.Info().Str("id", cam.ID).Msg("Stream started from backup sync")
+			activeIDs[cam.ID] = struct{}{}
+			if existing, exists := m.streams[cam.ID]; exists {
+				if !existing.MatchesConfig(cam.URL, cam.Record, cam.LazyHLS, cam.Transport) {
+					existing.Stop()
+					m.streams[cam.ID] = NewStream(cam.ID, cam.URL, cam.Record, cam.LazyHLS, cam.Transport)
+				}
+			} else {
+				m.streams[cam.ID] = NewStream(cam.ID, cam.URL, cam.Record, cam.LazyHLS, cam.Transport)
+				log.Info().Str("id", cam.ID).Msg("Stream started from backup sync")
+			}
 		} else {
 			log.Info().Str("id", cam.ID).Msg("Stream is disabled, skipping")
+		}
+	}
+	
+	// Остановка потоков, которых больше нет в активном списке
+	for id, st := range m.streams {
+		if _, ok := activeIDs[id]; !ok {
+			st.Stop()
+			delete(m.streams, id)
+			log.Info().Str("id", id).Msg("Stream stopped (removed or disabled in storage)")
 		}
 	}
 	

--- a/internal/stream/manager_test.go
+++ b/internal/stream/manager_test.go
@@ -104,3 +104,62 @@ func TestManager_SyncWithStorage(t *testing.T) {
 		t.Errorf("expected cam2 and cam3, got something else")
 	}
 }
+
+func TestManager_UpsertStream(t *testing.T) {
+	m := NewManager()
+
+	// 1. Создаем поток через UpsertStream
+	m.UpsertStream("cam1", "rtsp://test1", false, true, "tcp", false)
+	st1, ok := m.GetStream("cam1")
+	if !ok || st1 == nil {
+		t.Fatalf("expected cam1 to be created")
+	}
+	if !m.HasStream("cam1") {
+		t.Errorf("expected HasStream to return true for cam1")
+	}
+
+	// 2. Идемпотентный апсерт с теми же параметрами - стрим НЕ должен пересоздаваться
+	m.UpsertStream("cam1", "rtsp://test1", false, true, "tcp", false)
+	st1Same, _ := m.GetStream("cam1")
+	if st1 != st1Same {
+		t.Errorf("expected same stream instance when parameters are identical")
+	}
+
+	// 3. Апсерт с измененным URL - стрим ДОЛЖЕН пересоздаться
+	m.UpsertStream("cam1", "rtsp://test1-updated", false, true, "tcp", false)
+	st1Updated, _ := m.GetStream("cam1")
+	if st1 == st1Updated {
+		t.Errorf("expected new stream instance when URL is updated")
+	}
+	if st1Updated.URL != "rtsp://test1-updated" {
+		t.Errorf("expected updated URL, got %s", st1Updated.URL)
+	}
+
+	// 4. Апсерт с disabled=true - стрим ДОЛЖЕН быть остановлен и удален
+	m.UpsertStream("cam1", "rtsp://test1-updated", false, true, "tcp", true)
+	if m.HasStream("cam1") {
+		t.Errorf("expected cam1 to be removed when disabled")
+	}
+	if _, ok := m.GetStream("cam1"); ok {
+		t.Errorf("expected GetStream to return false for disabled cam1")
+	}
+}
+
+func TestManager_UpsertConcurrency(_ *testing.T) {
+	m := NewManager()
+	var wg sync.WaitGroup
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			camID := fmt.Sprintf("cam_%d", id%5)
+			for j := 0; j < 20; j++ {
+				disabled := (j % 2 == 1)
+				url := fmt.Sprintf("rtsp://server/%s_%d", camID, j)
+				m.UpsertStream(camID, url, false, true, "tcp", disabled)
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -277,6 +277,12 @@ func (s *Stream) Stop() {
 	}
 }
 
+// MatchesConfig проверяет, совпадают ли текущие параметры стрима с переданными.
+func (s *Stream) MatchesConfig(url string, record, lazyHLS bool, transport string) bool {
+	hasRecorder := s.mp4Recorder != nil
+	return s.URL == url && s.transport == transport && s.lazyHLS == lazyHLS && hasRecorder == record
+}
+
 // GetRingBuffer возвращает кольцевой буфер потока для чтения.
 func (s *Stream) GetRingBuffer() *buffer.RingBuffer {
 	return s.ringBuffer


### PR DESCRIPTION
## Summary

This pull request addresses the camera lifecycle invariant gap between durable storage (`pkg/storage` / BadgerDB) and the runtime stream manager (`internal/stream` / `internal/api`), tracked in #27 / #34:

1. **Atomic `StreamManager.UpsertStream` & Parameter Diffing (`internal/stream/`)**:
   - Added `MatchesConfig` on `Stream` to detect if streaming parameters (`URL`, `transport`, `lazyHLS`, `record`) actually changed.
   - Added `UpsertStream` to atomically update runtime streams without dropping active viewers when only metadata (tags/comments/etc.) changes.
   - Added `HasStream` helper.
   - Refactored `SyncWithStorage` to perform smooth reconciliation rather than abruptly stopping all active streams.
2. **Strict Invariant Guarantees in Camera API Handlers (`internal/api/handler.go`)**:
   - `AddCamera`: Enforces non-empty ID validation (`400 Bad Request`) and checks durable storage for duplicate IDs (`409 Conflict`), preventing silent overwrites and state divergence.
   - `EditCamera`: Enforces URL `:id` to body `req.ID` match, returns `404 Not Found` if camera doesn't exist, and synchronizes stream manager via `UpsertStream`.
   - `DeleteCamera`: Returns `404 Not Found` if camera doesn't exist, and ensures clean stream shutdown and storage deletion.
3. **Comprehensive Unit & Integration Test Suite**:
   - `internal/api/handler_camera_test.go`: Full coverage of camera lifecycle (create, duplicate conflict, not found, disable, enable, delete, dynamic state).
   - `internal/stream/manager_test.go`: Tests for `UpsertStream`, `HasStream`, and concurrent transitions.

## Validation

- `golangci-lint run ./...`: 0 issues
- `gosec -exclude-dir=pkg/grpc/pb ./...`: 0 issues
- `go test -v ./...`: all unit, integration, and E2E tests pass

Closes #34
Relates to #27