### PR TITLE
fix(stream): bound long-GOP buffering and handle RTP timestamp wrap, regressions, and codec changes

### DIFF
--- a/internal/buffer/ring.go
+++ b/internal/buffer/ring.go
@@ -167,6 +167,9 @@ func (rb *RingBuffer) Subscribe() *Reader {
 				r.C <- f
 			}
 		}
+	} else if rb.head > 0 {
+		// Если I-кадр не найден в истории (Long-GOP > capacity), требуем дождаться следующего I-кадра
+		r.NeedsIFrame.Store(true)
 	}
 	rb.mu.RUnlock()
 

--- a/internal/buffer/ring_test.go
+++ b/internal/buffer/ring_test.go
@@ -177,4 +177,43 @@ func TestReader_ReadContext(t *testing.T) {
 	}
 }
 
+func TestRingBuffer_LongGOP_RequiresIFrame(t *testing.T) {
+	rb := NewRingBuffer(5)
+	defer rb.Close()
+
+	// 1. Пишем 1 I-кадр и 6 P-кадров (I-кадр вымывается из буфера емкостью 5)
+	rb.Write(&Frame{IsKeyFrame: true, Timestamp: 1})
+	for i := 2; i <= 7; i++ {
+		rb.Write(&Frame{IsKeyFrame: false, Timestamp: time.Duration(i)})
+	}
+
+	// 2. Новый подписчик подключается к потоку, в истории которого нет I-кадра (Long GOP > capacity)
+	reader := rb.Subscribe()
+	defer reader.Close()
+
+	if !reader.NeedsIFrame.Load() {
+		t.Errorf("expected reader to require I-frame when historical GOP exceeds buffer capacity")
+	}
+
+	// 3. Пишем P-кадр -> читатель должен его пропустить
+	rb.Write(&Frame{IsKeyFrame: false, Timestamp: 8})
+	select {
+	case f := <-reader.C:
+		t.Fatalf("expected reader to ignore delta frame before I-frame, got frame: %v", f)
+	default:
+		// OK
+	}
+
+	// 4. Пишем I-кадр -> читатель должен его получить
+	rb.Write(&Frame{IsKeyFrame: true, Timestamp: 9})
+	select {
+	case f := <-reader.C:
+		if f.Timestamp != 9 || !f.IsKeyFrame {
+			t.Errorf("expected keyframe 9, got %v", f)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("expected reader to receive keyframe 9")
+	}
+}
+
 

--- a/internal/hls/muxer.go
+++ b/internal/hls/muxer.go
@@ -135,6 +135,14 @@ func (m *Muxer) run() {
 
 		m.lastFrameTime.Store(time.Now().UnixNano())
 
+		if frame.IsKeyFrame {
+			newVps, newSps, newPps := m.ringBuffer.GetParams()
+			if (!bytes.Equal(sps, newSps) || !bytes.Equal(pps, newPps) || !bytes.Equal(vps, newVps)) && newSps != nil {
+				vps, sps, pps = newVps, newSps, newPps
+				m.needsDiscontinuity = true
+			}
+		}
+
 		// Если текущий сегмент достиг целевой длины и пришел новый I-кадр, закрываем сегмент
 		if currentBuf != nil && frame.IsKeyFrame && frame.Timestamp-segmentStart >= m.targetDuration {
 			m.currentMetaMu.Lock()

--- a/internal/hls/muxer_test.go
+++ b/internal/hls/muxer_test.go
@@ -137,6 +137,66 @@ func TestMuxer_BoundedStopWithIdleStream(t *testing.T) {
 	}
 }
 
+func TestMuxer_DynamicCodecChange_Discontinuity(t *testing.T) {
+	rb := buffer.NewRingBuffer(10)
+	defer rb.Close()
+
+	// Initial SPS/PPS (e.g. 1080p)
+	sps1 := []byte{0x67, 0x42, 0x00, 0x0a, 0xf8, 0x41, 0xa2}
+	pps1 := []byte{0x68, 0xce, 0x38, 0x80}
+	rb.SetParams(nil, sps1, pps1)
+
+	muxer := NewMuxer("test_codec_change", rb, nil, nil)
+	muxer.targetDuration = 100 * time.Millisecond
+	defer muxer.Stop()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// 1. First segment with SPS1
+	rb.Write(&buffer.Frame{
+		IsKeyFrame: true,
+		Timestamp:  0,
+		NALUs:      [][]byte{{0x65, 0x01}},
+	})
+	rb.Write(&buffer.Frame{
+		IsKeyFrame: false,
+		Timestamp:  50 * time.Millisecond,
+		NALUs:      [][]byte{{0x41, 0x02}},
+	})
+	// Trigger first segment close
+	rb.Write(&buffer.Frame{
+		IsKeyFrame: true,
+		Timestamp:  150 * time.Millisecond,
+		NALUs:      [][]byte{{0x65, 0x03}},
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	// 2. Camera changes SPS/PPS on the fly (e.g. resolution change to 720p)
+	sps2 := []byte{0x67, 0x42, 0x00, 0x1f, 0xf8, 0x41, 0xa2} // different profile/level
+	rb.SetParams(nil, sps2, pps1)
+
+	// Write keyframe with new SPS parameters
+	rb.Write(&buffer.Frame{
+		IsKeyFrame: false,
+		Timestamp:  200 * time.Millisecond,
+		NALUs:      [][]byte{{0x41, 0x04}},
+	})
+	// Trigger second segment close
+	rb.Write(&buffer.Frame{
+		IsKeyFrame: true,
+		Timestamp:  300 * time.Millisecond,
+		NALUs:      [][]byte{{0x65, 0x05}},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	playlist := muxer.GetPlaylist()
+	if !strings.Contains(playlist, "#EXT-X-DISCONTINUITY") {
+		t.Fatalf("expected playlist to contain #EXT-X-DISCONTINUITY on codec param change, got:\n%s", playlist)
+	}
+}
+
 func BenchmarkMuxer_GetPlaylist(b *testing.B) {
 	rb := buffer.NewRingBuffer(10)
 	defer rb.Close()

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -60,6 +60,7 @@ func (r *Recorder) run() {
 	var pendingSample *fmp4.PartSample
 	var initialPts int64 = -1
 	var currentFilename string
+	var lastGoodDuration uint32 = 90000 / 25
 
 	closeAndFinalize := func(isError bool) {
 		if file != nil {
@@ -128,7 +129,7 @@ func (r *Recorder) run() {
 		// Ротация файла каждый час. Проверяем перед обработкой I-кадра.
 		if file != nil && frame.IsKeyFrame && time.Since(recordStartTime) > 1*time.Hour {
 			if pendingSample != nil {
-				pendingSample.Duration = 90000 / 25
+				pendingSample.Duration = lastGoodDuration
 				partSamples = append(partSamples, pendingSample)
 			}
 			if len(partSamples) > 0 {
@@ -245,9 +246,10 @@ func (r *Recorder) run() {
 		if pendingSample != nil {
 			dur := currentPts - lastPts
 			if dur <= 0 || dur > 90000*5 { // Защита от регрессий, джиттера B-кадров и аномальных скачков
-				pendingSample.Duration = 90000 / 25
+				pendingSample.Duration = lastGoodDuration
 			} else {
-				pendingSample.Duration = uint32(dur) // #nosec G115 -- dur is bounded <= 90000*5
+				lastGoodDuration = uint32(dur) // #nosec G115 -- dur is bounded <= 90000*5
+				pendingSample.Duration = lastGoodDuration
 			}
 			partSamples = append(partSamples, pendingSample)
 		}
@@ -302,7 +304,7 @@ ExitLoop:
 
 	if file != nil {
 		if pendingSample != nil {
-			pendingSample.Duration = 90000 / 25
+			pendingSample.Duration = lastGoodDuration
 			partSamples = append(partSamples, pendingSample)
 		}
 		if len(partSamples) > 0 {

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -243,7 +243,12 @@ func (r *Recorder) run() {
 
 		// Устанавливаем Duration для предыдущего сэмпла
 		if pendingSample != nil {
-			pendingSample.Duration = uint32(currentPts - lastPts) // #nosec G115 -- duration fits within uint32
+			dur := currentPts - lastPts
+			if dur <= 0 || dur > 90000*5 { // Защита от регрессий, джиттера B-кадров и аномальных скачков
+				pendingSample.Duration = 90000 / 25
+			} else {
+				pendingSample.Duration = uint32(dur) // #nosec G115 -- dur is bounded <= 90000*5
+			}
 			partSamples = append(partSamples, pendingSample)
 		}
 

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -106,6 +106,70 @@ func TestRecorder_EmptySegmentCleaned(t *testing.T) {
 	}
 }
 
+func TestRecorder_TimestampRegression_And_BFrames(t *testing.T) {
+	tempDir := t.TempDir()
+	rb := buffer.NewRingBuffer(10)
+	
+	sps := []byte{0x67, 0x42, 0x00, 0x0a, 0xf8, 0x41, 0xa2}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	rb.SetParams(nil, sps, pps)
+
+	r := NewRecorder("cam_bframe", rb, tempDir, nil)
+	time.Sleep(50 * time.Millisecond)
+
+	// 1. Keyframe at PTS = 1s
+	rb.Write(&buffer.Frame{
+		Timestamp:  1 * time.Second,
+		IsKeyFrame: true,
+		NALUs:      [][]byte{{0x05, 0x01, 0x02, 0x03}},
+	})
+
+	// 2. Forward P-frame at PTS = 1.08s
+	time.Sleep(10 * time.Millisecond)
+	rb.Write(&buffer.Frame{
+		Timestamp:  1080 * time.Millisecond,
+		IsKeyFrame: false,
+		NALUs:      [][]byte{{0x01, 0x04}},
+	})
+
+	// 3. Reordered B-frame (backward regression in PTS = 1.04s)
+	time.Sleep(10 * time.Millisecond)
+	rb.Write(&buffer.Frame{
+		Timestamp:  1040 * time.Millisecond, // PTS < lastPts
+		IsKeyFrame: false,
+		NALUs:      [][]byte{{0x01, 0x05}},
+	})
+
+	// 4. Another Keyframe at PTS = 2s
+	time.Sleep(10 * time.Millisecond)
+	rb.Write(&buffer.Frame{
+		Timestamp:  2 * time.Second,
+		IsKeyFrame: true,
+		NALUs:      [][]byte{{0x05, 0x06}},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+	r.Stop()
+	rb.Close()
+
+	// Verify the generated file is structurally valid and can be validated
+	camDir := filepath.Join(tempDir, "cam_bframe")
+	entries, err := os.ReadDir(camDir)
+	if err != nil || len(entries) == 0 {
+		t.Fatalf("expected recorded files in %s, err: %v", camDir, err)
+	}
+
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".mp4") {
+			filePath := filepath.Join(camDir, entry.Name())
+			valid, valErr := ValidateFMP4File(filePath)
+			if !valid || valErr != nil {
+				t.Errorf("expected valid fMP4 with B-frames/regressions, got valid=%v, err=%v", valid, valErr)
+			}
+		}
+	}
+}
+
 func BenchmarkRecorder_FMP4_Write_GOP(b *testing.B) {
 	tempDir := b.TempDir()
 	filePath := filepath.Join(tempDir, "bench.mp4")

--- a/internal/rtsp/client.go
+++ b/internal/rtsp/client.go
@@ -126,6 +126,8 @@ func (c *Client) Start(ctx context.Context, onFrame OnFrameCallback, onParams On
 	releaseSemaphore()
 
 
+	tsUnwrapper := NewTimestampUnwrapper()
+
 	// Ищем видео трек (H264 или H265) и подписываемся на него
 	for _, media := range session.Medias {
 		for _, forma := range media.Formats {
@@ -145,7 +147,8 @@ func (c *Client) Start(ctx context.Context, onFrame OnFrameCallback, onParams On
 					nalus, err := rtpDec.Decode(pkt)
 					if err == nil && len(nalus) > 0 {
 						isKeyFrame := false
-						pts := time.Duration(pkt.Timestamp) * time.Second / 90000
+						unwrappedTS := tsUnwrapper.Unwrap(pkt.Timestamp)
+						pts := time.Duration(unwrappedTS * uint64(time.Second) / 90000) // #nosec G115 -- unwrapped timestamp fits within int64 duration
 
 						for _, nalu := range nalus {
 							if len(nalu) > 0 {
@@ -174,7 +177,8 @@ func (c *Client) Start(ctx context.Context, onFrame OnFrameCallback, onParams On
 					nalus, err := rtpDec.Decode(pkt)
 					if err == nil && len(nalus) > 0 {
 						isKeyFrame := false
-						pts := time.Duration(pkt.Timestamp) * time.Second / 90000
+						unwrappedTS := tsUnwrapper.Unwrap(pkt.Timestamp)
+						pts := time.Duration(unwrappedTS * uint64(time.Second) / 90000) // #nosec G115 -- unwrapped timestamp fits within int64 duration
 
 						for _, nalu := range nalus {
 							if len(nalu) > 0 {

--- a/internal/rtsp/timestamp.go
+++ b/internal/rtsp/timestamp.go
@@ -1,0 +1,44 @@
+package rtsp
+
+import "sync"
+
+// TimestampUnwrapper преобразует 32-битные циклические RTP-таймстампы (переполняющиеся каждые ~13.2 часа при 90 кГц)
+// в непрерывную монотонно возрастающую 64-битную временную шкалу.
+type TimestampUnwrapper struct {
+	mu          sync.Mutex
+	lastTS      uint32
+	epoch       uint64
+	initialized bool
+}
+
+// NewTimestampUnwrapper создает новый экземпляр разворачивателя таймстампов.
+func NewTimestampUnwrapper() *TimestampUnwrapper {
+	return &TimestampUnwrapper{}
+}
+
+// Unwrap принимает 32-битный RTP timestamp и возвращает 64-битный развернутый timestamp.
+func (u *TimestampUnwrapper) Unwrap(ts uint32) uint64 {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if !u.initialized {
+		u.lastTS = ts
+		u.epoch = 0
+		u.initialized = true
+		return uint64(ts)
+	}
+
+	// Переполнение вперед через границу 2^32-1 -> 0
+	// Если новое значение меньше предыдущего более чем на половину диапазона (0x80000000)
+	if ts < u.lastTS && (u.lastTS-ts) > 0x80000000 {
+		u.epoch += 1 << 32
+	} else if ts > u.lastTS && (ts-u.lastTS) > 0x80000000 {
+		// Переполнение назад (редкий скачок часов назад через границу)
+		if u.epoch >= (1 << 32) {
+			u.epoch -= 1 << 32
+		}
+	}
+
+	u.lastTS = ts
+	return u.epoch + uint64(ts)
+}

--- a/internal/rtsp/timestamp_test.go
+++ b/internal/rtsp/timestamp_test.go
@@ -66,3 +66,48 @@ func TestTimestampUnwrapper_BFrame_SmallJitter(t *testing.T) {
 		t.Errorf("expected 13000, got %d", u3)
 	}
 }
+
+func TestTimestampUnwrapper_ReorderedSequence(t *testing.T) {
+	u := NewTimestampUnwrapper()
+
+	// Последовательность с reordering: 100000 -> 101000 -> 100500 -> 102000
+	seq := []struct {
+		in       uint32
+		expected uint64
+	}{
+		{100000, 100000},
+		{101000, 101000},
+		{100500, 100500},
+		{102000, 102000},
+	}
+
+	for i, s := range seq {
+		got := u.Unwrap(s.in)
+		if got != s.expected {
+			t.Errorf("step %d (in=%d): expected %d, got %d", i, s.in, s.expected, got)
+		}
+	}
+}
+
+func TestTimestampUnwrapper_OutOfOrderRollover(t *testing.T) {
+	u := NewTimestampUnwrapper()
+
+	// Пакеты переупорядочены прямо вокруг границы rollover:
+	// 0xFFFFFFFE (before rollover)
+	// 0x00000001 (after rollover -> epoch increases)
+	// 0xFFFFFFFF (late packet before rollover -> epoch rolls back symmetrically)
+	u1 := u.Unwrap(0xFFFFFFFE)
+	if u1 != 0xFFFFFFFE {
+		t.Errorf("expected 0xFFFFFFFE, got %d", u1)
+	}
+
+	u2 := u.Unwrap(0x00000001)
+	if u2 != (1<<32)+1 {
+		t.Errorf("expected %d, got %d", (uint64(1)<<32)+1, u2)
+	}
+
+	u3 := u.Unwrap(0xFFFFFFFF)
+	if u3 != 0xFFFFFFFF {
+		t.Errorf("expected 0xFFFFFFFF after out-of-order wrap recovery, got %d", u3)
+	}
+}

--- a/internal/rtsp/timestamp_test.go
+++ b/internal/rtsp/timestamp_test.go
@@ -1,0 +1,68 @@
+package rtsp
+
+import (
+	"testing"
+)
+
+func TestTimestampUnwrapper_Sequential(t *testing.T) {
+	u := NewTimestampUnwrapper()
+
+	ts1 := u.Unwrap(1000)
+	if ts1 != 1000 {
+		t.Errorf("expected 1000, got %d", ts1)
+	}
+
+	ts2 := u.Unwrap(4600)
+	if ts2 != 4600 {
+		t.Errorf("expected 4600, got %d", ts2)
+	}
+
+	ts3 := u.Unwrap(8200)
+	if ts3 != 8200 {
+		t.Errorf("expected 8200, got %d", ts3)
+	}
+}
+
+func TestTimestampUnwrapper_Rollover(t *testing.T) {
+	u := NewTimestampUnwrapper()
+
+	// Начинаем близко к границе 2^32-1 (0xFFFFFFFF = 4294967295)
+	startTS := uint32(0xFFFFFF00)
+	u1 := u.Unwrap(startTS)
+	if u1 != uint64(startTS) {
+		t.Errorf("expected %d, got %d", uint64(startTS), u1)
+	}
+
+	// Переходим через 0
+	wrappedTS := uint32(0x000000FF)
+	u2 := u.Unwrap(wrappedTS)
+
+	expectedU2 := uint64(1<<32) + uint64(wrappedTS)
+	if u2 != expectedU2 {
+		t.Errorf("expected %d after rollover, got %d", expectedU2, u2)
+	}
+
+	// Следующий кадр
+	nextTS := uint32(0x00000FFF)
+	u3 := u.Unwrap(nextTS)
+	expectedU3 := uint64(1<<32) + uint64(nextTS)
+	if u3 != expectedU3 {
+		t.Errorf("expected %d, got %d", expectedU3, u3)
+	}
+}
+
+func TestTimestampUnwrapper_BFrame_SmallJitter(t *testing.T) {
+	u := NewTimestampUnwrapper()
+
+	// Небольшой откат назад (B-кадр с меньшим PTS в потоке декодирования) не должен триггерить rollover
+	u.Unwrap(10000)
+	u2 := u.Unwrap(9500) // -500 ticks
+	if u2 != 9500 {
+		t.Errorf("expected 9500 for small backward jitter, got %d", u2)
+	}
+
+	u3 := u.Unwrap(13000)
+	if u3 != 13000 {
+		t.Errorf("expected 13000, got %d", u3)
+	}
+}


### PR DESCRIPTION
## Summary

This pull request implements long-GOP buffering bounds, continuous 64-bit RTP timestamp unrolling across 32-bit wrap boundaries, sample duration regression protection for B-frames, and dynamic codec parameter update detection, resolving the items tracked in #27 / #40:

1. **Long-GOP RingBuffer Bounds (`internal/buffer/ring.go`)**:
   - In `RingBuffer.Subscribe()`: if no keyframe exists in historical buffer (e.g. GOP length exceeds buffer capacity), `r.NeedsIFrame.Store(true)` is enforced so new subscribers do not receive orphan delta frames before the next I-frame.
2. **RTP Timestamp Unwrapping Across Rollovers (`internal/rtsp/timestamp.go`, `internal/rtsp/client.go`)**:
   - Created `TimestampUnwrapper` to unroll 32-bit uint32 RTP timestamps into a continuous 64-bit domain across $2^{32}-1 \to 0$ rollover boundaries (~every 13.2h on 90kHz clocks).
3. **Timestamp Regression & B-Frame Duration Safety (`internal/recorder/recorder.go`)**:
   - Clamped sample durations $\le 0$ or $> 90000*5$ to nominal frame duration (`90000 / 25`), preventing integer underflow during camera clock jitter or B-frame reordering.
4. **Dynamic Codec Parameter Change Detection (`internal/hls/muxer.go`)**:
   - Compares VPS/SPS/PPS on keyframes and sets `needsDiscontinuity = true` when changes occur, inserting `#EXT-X-DISCONTINUITY` in HLS playlists.
5. **Comprehensive Test Suite**:
   - `internal/rtsp/timestamp_test.go`: Tests sequential unwrapping, $2^{32}$ rollover, and small backward jitter.
   - `internal/buffer/ring_test.go`: Added `TestRingBuffer_LongGOP_RequiresIFrame`.
   - `internal/recorder/recorder_test.go`: Added `TestRecorder_TimestampRegression_And_BFrames`.

## Validation

- `golangci-lint run ./...`: 0 issues
- `gosec -exclude-dir=pkg/grpc/pb ./...`: 0 issues
- `go test -v ./...`: all unit, fuzz, integration, and E2E tests pass

Closes #40
Relates to #27