### PR TITLE
fix(recorder): enforce strict box boundary checks in fMP4 validator and clarify finalization semantics

### DIFF
--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -62,7 +62,7 @@ func (r *Recorder) run() {
 	var currentFilename string
 	var lastGoodDuration uint32 = 90000 / 25
 
-	closeAndFinalize := func(isError bool) {
+	finalize := func(isError bool) {
 		if file != nil {
 			_ = file.Close()
 			switch {
@@ -92,10 +92,13 @@ func (r *Recorder) run() {
 		}
 	}
 
+	finalizeSuccess := func() { finalize(false) }
+	finalizeFailure := func() { finalize(true) }
+
 	defer func() {
 		if err := recover(); err != nil {
 			log.Error().Interface("panic", err).Str("streamID", r.streamID).Msg("Recovered from panic in Recorder.run")
-			closeAndFinalize(true)
+			finalizeFailure()
 		}
 	}()
 
@@ -145,7 +148,7 @@ func (r *Recorder) run() {
 					if r.onDegraded != nil {
 						r.onDegraded(true)
 					}
-					closeAndFinalize(true)
+					finalizeFailure()
 					pendingSample = nil
 					partSamples = partSamples[:0]
 					initialPts = -1
@@ -166,7 +169,7 @@ func (r *Recorder) run() {
 			}
 			
 			log.Info().Str("stream", r.streamID).Msg("Rotating record file")
-			closeAndFinalize(false)
+			finalizeSuccess()
 			pendingSample = nil
 			partSamples = partSamples[:0]
 			initialPts = -1
@@ -227,7 +230,7 @@ func (r *Recorder) run() {
 				if r.onDegraded != nil {
 					r.onDegraded(true)
 				}
-				closeAndFinalize(true)
+				finalizeFailure()
 				continue
 			}
 
@@ -276,7 +279,7 @@ func (r *Recorder) run() {
 				if r.onDegraded != nil {
 					r.onDegraded(true)
 				}
-				closeAndFinalize(true)
+				finalizeFailure()
 				pendingSample = nil
 				partSamples = partSamples[:0]
 				initialPts = -1
@@ -320,7 +323,7 @@ ExitLoop:
 				partsWritten++
 			}
 		}
-		closeAndFinalize(false)
+		finalizeSuccess()
 	}
 }
 

--- a/internal/recorder/recorder_test.go
+++ b/internal/recorder/recorder_test.go
@@ -4,10 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/RUSEGAL/ruseon-core/internal/buffer"
+	"github.com/RUSEGAL/ruseon-core/pkg/registry"
 	"github.com/bluenviron/mediacommon/pkg/formats/fmp4"
 )
 
@@ -167,6 +169,59 @@ func TestRecorder_TimestampRegression_And_BFrames(t *testing.T) {
 				t.Errorf("expected valid fMP4 with B-frames/regressions, got valid=%v, err=%v", valid, valErr)
 			}
 		}
+	}
+}
+
+type mockRecorderBus struct {
+	events map[string]int
+	mu     sync.Mutex
+}
+
+func (m *mockRecorderBus) Publish(topic string, _ string, _ any) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events[topic]++
+}
+
+func (m *mockRecorderBus) Stop() {}
+
+func TestRecorder_EventExclusivity_OnFailure(t *testing.T) {
+	tempDir := t.TempDir()
+	rb := buffer.NewRingBuffer(10)
+
+	mockBus := &mockRecorderBus{events: make(map[string]int)}
+	oldBus := registry.CurrentEventBus
+	registry.CurrentEventBus = mockBus
+	defer func() { registry.CurrentEventBus = oldBus }()
+
+	// Set invalid SPS so fMP4 Init write fails immediately
+	invalidSPS := []byte{0x00, 0x00}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	rb.SetParams(nil, invalidSPS, pps)
+
+	r := NewRecorder("cam_err_test", rb, tempDir, nil)
+	time.Sleep(50 * time.Millisecond)
+
+	rb.Write(&buffer.Frame{
+		IsKeyFrame: true,
+		Timestamp:  0,
+		NALUs:      [][]byte{{0x05, 0x01}},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+	r.Stop()
+	rb.Close()
+
+	mockBus.mu.Lock()
+	failedCount := mockBus.events["recording_failed"]
+	readyCount := mockBus.events["archive_segment_ready"]
+	mockBus.mu.Unlock()
+
+	if failedCount != 1 {
+		t.Errorf("expected exactly 1 recording_failed event, got %d", failedCount)
+	}
+	if readyCount != 0 {
+		t.Errorf("expected 0 archive_segment_ready events on error, got %d", readyCount)
 	}
 }
 

--- a/internal/recorder/recovery.go
+++ b/internal/recorder/recovery.go
@@ -15,8 +15,10 @@ import (
 
 // ValidateFMP4File проверяет структурную целостность fMP4 файла:
 // 1. Размер файла не менее 32 байт.
-// 2. Наличие валидного блока инициализации (moov).
-// 3. Наличие хотя бы одного медиа-фрагмента (moof + mdat).
+// 2. Все box'ы корректно укладываются в физический размер файла (box.offset + box.size <= fileSize).
+// 3. Файл завершается ровно по границе box'ов (нет оборванных trailing данных).
+// 4. Наличие валидного блока инициализации (moov).
+// 5. Наличие хотя бы одного медиа-фрагмента (moof + mdat).
 func ValidateFMP4File(path string) (bool, error) {
 	file, err := registry.CurrentBlobStore.Open(path)
 	if err != nil {
@@ -28,21 +30,31 @@ func ValidateFMP4File(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if stat.Size() < 32 {
-		return false, fmt.Errorf("fMP4 file size too small: %d bytes", stat.Size())
+	fileSize := stat.Size()
+	if fileSize < 32 {
+		return false, fmt.Errorf("fMP4 file size too small: %d bytes", fileSize)
 	}
 
+	var currentOffset int64
 	var hasMoov, hasMoof, hasMdat bool
-	for {
+
+	for currentOffset < fileSize {
+		if currentOffset+8 > fileSize {
+			return false, fmt.Errorf("truncated box header at offset %d (file size %d)", currentOffset, fileSize)
+		}
+
 		var header [8]byte
 		if _, err := io.ReadFull(file, header[:]); err != nil {
-			break
+			return false, fmt.Errorf("failed to read box header at offset %d: %w", currentOffset, err)
 		}
-		size := binary.BigEndian.Uint32(header[0:4])
+		size := int64(binary.BigEndian.Uint32(header[0:4]))
 		boxType := string(header[4:8])
 
 		if size < 8 {
-			break
+			return false, fmt.Errorf("invalid box size %d for box '%s' at offset %d", size, boxType, currentOffset)
+		}
+		if currentOffset+size > fileSize {
+			return false, fmt.Errorf("box '%s' at offset %d declares size %d which exceeds file size %d", boxType, currentOffset, size, fileSize)
 		}
 
 		switch boxType {
@@ -54,10 +66,9 @@ func ValidateFMP4File(path string) (bool, error) {
 			hasMdat = true
 		}
 
-		// #nosec G115 -- box size fits into int64
-		remaining := int64(size) - 8
-		if _, err := file.Seek(remaining, io.SeekCurrent); err != nil {
-			break
+		currentOffset += size
+		if _, err := file.Seek(size-8, io.SeekCurrent); err != nil {
+			return false, fmt.Errorf("failed to seek past box '%s': %w", boxType, err)
 		}
 	}
 

--- a/internal/recorder/recovery_test.go
+++ b/internal/recorder/recovery_test.go
@@ -141,3 +141,67 @@ func TestRecoverCrashedFiles(t *testing.T) {
 		t.Errorf("normal file should not have been touched")
 	}
 }
+
+func TestValidateFMP4File_TruncatedBoxPayload(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "truncated_box.mp4")
+
+	// 1. Создаем валидный fMP4
+	if err := createValidFMP4File(filePath); err != nil {
+		t.Fatalf("failed to create valid fMP4: %v", err)
+	}
+
+	// 2. Дописываем заголовок mdat, заявляющий 1 МБ (1048576 байт), но с телом всего в 16 байт
+	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		t.Fatalf("failed to open file: %v", err)
+	}
+	// 4 байта size (0x00100000 = 1048576) + 4 байта type "mdat"
+	var fakeHeader [8]byte
+	fakeHeader[0] = 0x00
+	fakeHeader[1] = 0x10
+	fakeHeader[2] = 0x00
+	fakeHeader[3] = 0x00
+	copy(fakeHeader[4:8], "mdat")
+	_, _ = file.Write(fakeHeader[:])
+	_, _ = file.Write(make([]byte, 16)) // пишем только 16 байт вместо 1048568
+	file.Close()
+
+	// 3. Валидатор должен обнаружить превышение размера над физической длиной файла
+	valid, err := ValidateFMP4File(filePath)
+	if valid || err == nil {
+		t.Errorf("expected ValidateFMP4File to fail for truncated box payload, got valid=%v, err=%v", valid, err)
+	}
+}
+
+func TestRecoverCrashedFiles_TruncatedTrailingFragment(t *testing.T) {
+	tempDir := t.TempDir()
+	camDir := filepath.Join(tempDir, "cam_truncated")
+	_ = os.MkdirAll(camDir, 0755)
+
+	truncatedOngoingPath := filepath.Join(camDir, "2026-07-31_17-00-00_ongoing.mp4")
+	if err := createValidFMP4File(truncatedOngoingPath); err != nil {
+		t.Fatalf("failed to create valid fMP4: %v", err)
+	}
+
+	// Дописываем обрезанный moof/mdat
+	file, _ := os.OpenFile(truncatedOngoingPath, os.O_WRONLY|os.O_APPEND, 0600)
+	var fakeHeader [8]byte
+	fakeHeader[0] = 0x00
+	fakeHeader[1] = 0x05
+	fakeHeader[2] = 0x00
+	fakeHeader[3] = 0x00
+	copy(fakeHeader[4:8], "moof")
+	_, _ = file.Write(fakeHeader[:])
+	_, _ = file.Write(make([]byte, 10))
+	file.Close()
+
+	// Запускаем восстановление
+	RecoverCrashedFiles(tempDir)
+
+	// Файл должен быть изолирован в .corrupted, а не переименован в .mp4
+	corruptedTarget := filepath.Join(camDir, "2026-07-31_17-00-00_ongoing.corrupted")
+	if _, err := os.Stat(corruptedTarget); os.IsNotExist(err) {
+		t.Errorf("expected truncated ongoing recording to be isolated as .corrupted, not found at %s", corruptedTarget)
+	}
+}


### PR DESCRIPTION
## Summary

This pull request implements strict physical box boundary verification in `ValidateFMP4File`, refactors recorder finalization into explicit `finalizeSuccess()` / `finalizeFailure()` functions, and adds comprehensive crash and event exclusivity tests, addressing the audit feedback for PR #37 and tracked in #27 / #42:

1. **Strict Box Boundary & Size Verification (`internal/recorder/recovery.go`)**:
   - `ValidateFMP4File` now verifies that `currentOffset + box.size <= fileSize` for each atom/box and ensures clean file termination on a box boundary (`currentOffset == fileSize`).
   - Prevents false-positive validation of files where a crash occurred during payload (`mdat`) writes.
2. **Explicit Finalization Semantics (`internal/recorder/recorder.go`)**:
   - Refactored boolean parameter `closeAndFinalize(bool)` into self-documenting `finalizeSuccess()` and `finalizeFailure()` calls.
3. **Comprehensive Edge-Case Testing**:
   - `internal/recorder/recovery_test.go`: Added `TestValidateFMP4File_TruncatedBoxPayload` (testing rejection of files with truncated `mdat` payload).
   - `internal/recorder/recovery_test.go`: Added `TestRecoverCrashedFiles_TruncatedTrailingFragment` (testing safe `.corrupted` isolation of multi-fragment files with truncated trailing parts).
   - `internal/recorder/recorder_test.go`: Added `TestRecorder_EventExclusivity_OnFailure` (testing that write errors emit `recording_failed` and strictly suppress `archive_segment_ready`).

## Validation

- `golangci-lint run ./...`: 0 issues
- `gosec -exclude-dir=pkg/grpc/pb ./...`: 0 issues
- `go test -v ./...`: all unit, fuzz, integration, and E2E tests pass

Closes #42
Relates to #27