### PR TITLE
feat(security): Phase 1 — security hardening & input boundaries (#62)

### DIFF
--- a/internal/api/cors_test.go
+++ b/internal/api/cors_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/RUSEGAL/ruseon-core/pkg/auth"
+	"github.com/RUSEGAL/ruseon-core/pkg/config"
 )
 
 func TestRouterCORS(t *testing.T) {
@@ -53,5 +54,41 @@ func TestRouterCORS(t *testing.T) {
 				t.Errorf("expected no Allow-Origin header, got %q", originHeader)
 			}
 		})
+	}
+}
+
+func TestWSOriginCheck(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Server.CORSAllowedOrigins = []string{"https://dashboard.example.com"}
+	h := &Handler{cfg: cfg}
+
+	// 1. Matching origin
+	req1, _ := http.NewRequest("GET", "/stream/ws/cam1", nil)
+	req1.Header.Set("Origin", "https://dashboard.example.com")
+	if !h.checkWSOrigin(req1) {
+		t.Errorf("expected origin to be allowed")
+	}
+
+	// 2. Non-matching origin
+	req2, _ := http.NewRequest("GET", "/stream/ws/cam1", nil)
+	req2.Header.Set("Origin", "https://evil.com")
+	if h.checkWSOrigin(req2) {
+		t.Errorf("expected evil origin to be rejected")
+	}
+
+	// 3. No origin header (non-browser client)
+	req3, _ := http.NewRequest("GET", "/stream/ws/cam1", nil)
+	if !h.checkWSOrigin(req3) {
+		t.Errorf("expected empty origin to be allowed")
+	}
+
+	// 4. Wildcard origin
+	cfgWildcard := &config.Config{}
+	cfgWildcard.Server.CORSAllowedOrigins = []string{"*"}
+	hWildcard := &Handler{cfg: cfgWildcard}
+	req4, _ := http.NewRequest("GET", "/stream/ws/cam1", nil)
+	req4.Header.Set("Origin", "https://anything.com")
+	if !hWildcard.checkWSOrigin(req4) {
+		t.Errorf("expected wildcard origin to be allowed")
 	}
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"runtime"
 	"strconv"
@@ -933,11 +934,18 @@ func (h *Handler) ExportBackupJSON(c *gin.Context) {
 	c.Data(http.StatusOK, "application/json", data)
 }
 
+const maxBackupSize = 50 << 20 // 50 MB
+
 // ImportBackupJSON принимает JSON-файл дампа и восстанавливает конфигурации камер и тегов.
 func (h *Handler) ImportBackupJSON(c *gin.Context) {
 	file, err := c.FormFile("backup")
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "No backup file provided"})
+		return
+	}
+
+	if file.Size > maxBackupSize {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Backup file exceeds maximum allowed size (50MB)"})
 		return
 	}
 
@@ -948,8 +956,8 @@ func (h *Handler) ImportBackupJSON(c *gin.Context) {
 	}
 	defer f.Close()
 
-	data := make([]byte, file.Size)
-	if _, err := f.Read(data); err != nil {
+	data, err := io.ReadAll(io.LimitReader(f, maxBackupSize))
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read uploaded file"})
 		return
 	}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -467,28 +467,45 @@ func TestImportBackupJSON(t *testing.T) {
 	
 	router.POST("/api/backup/import", handler.ImportBackupJSON)
 	
-	backupData := []byte(`{"cameras":[{"id":"import1","url":"rtsp://import"}],"tags":[{"id":"tag1","name":"T"}]}`)
-	
-	body := new(bytes.Buffer)
-	writer := multipart.NewWriter(body)
-	part, _ := writer.CreateFormFile("backup", "backup.json")
-	part.Write(backupData)
-	writer.Close()
-	
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/api/backup/import", body)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	router.ServeHTTP(w, req)
-	
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200 for import, got %d", w.Code)
-	}
-	
-	// check DB
-	cam, err := store.GetCamera("import1")
-	if err != nil || cam.URL != "rtsp://import" {
-		t.Fatalf("camera not imported correctly")
-	}
+	t.Run("valid backup import", func(t *testing.T) {
+		backupData := []byte(`{"cameras":[{"id":"import1","url":"rtsp://import"}],"tags":[{"id":"tag1","name":"T"}]}`)
+		
+		body := new(bytes.Buffer)
+		writer := multipart.NewWriter(body)
+		part, _ := writer.CreateFormFile("backup", "backup.json")
+		part.Write(backupData)
+		writer.Close()
+		
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/backup/import", body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		router.ServeHTTP(w, req)
+		
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 for import, got %d", w.Code)
+		}
+		
+		// check DB
+		cam, err := store.GetCamera("import1")
+		if err != nil || cam.URL != "rtsp://import" {
+			t.Fatalf("camera not imported correctly")
+		}
+	})
+
+	t.Run("missing backup file in request", func(t *testing.T) {
+		body := new(bytes.Buffer)
+		writer := multipart.NewWriter(body)
+		writer.Close()
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/api/backup/import", body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for missing file, got %d", w.Code)
+		}
+	})
 }
 
 func TestArchiveEndpoints(t *testing.T) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -56,14 +56,14 @@ func TestRouterMiddleware(t *testing.T) {
 		t.Errorf("expected 401 for invalid token, got %d", w3.Code)
 	}
 
-	// 4. Test Auth Middleware - Valid Token (Query param)
+	// 4. Test Auth Middleware - Query param token rejected for main API
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"username": "admin", "role": string(models.RoleAdmin)})
 	tokenString, _ := token.SignedString([]byte("secret"))
 	w4 := httptest.NewRecorder()
 	req4, _ := http.NewRequest("GET", "/api/cameras?token="+tokenString, nil)
 	router.ServeHTTP(w4, req4)
-	if w4.Code != http.StatusOK {
-		t.Errorf("expected 200 for valid token, got %d", w4.Code)
+	if w4.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for query param token on API, got %d", w4.Code)
 	}
 
 	// 5. Test Auth Middleware - Valid Token (Header)

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -11,12 +11,29 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var wsUpgrader = websocket.Upgrader{
-	CheckOrigin: func(_ *http.Request) bool {
-		return true // CORS handled by upper middleware
-	},
-	ReadBufferSize:  1024,
-	WriteBufferSize: 64 * 1024,
+func (h *Handler) checkWSOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	// Allow non-browser clients with no Origin header
+	if origin == "" {
+		return true
+	}
+	if h.cfg == nil || len(h.cfg.Server.CORSAllowedOrigins) == 0 {
+		return true
+	}
+	for _, o := range h.cfg.Server.CORSAllowedOrigins {
+		if o == "*" || o == origin {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *Handler) getWSUpgrader() websocket.Upgrader {
+	return websocket.Upgrader{
+		CheckOrigin:     h.checkWSOrigin,
+		ReadBufferSize:  1024,
+		WriteBufferSize: 64 * 1024,
+	}
 }
 
 // StreamWS handles binary WebCodecs streaming over WebSocket.
@@ -47,7 +64,8 @@ func (h *Handler) StreamWS(c *gin.Context) {
 		return
 	}
 
-	conn, err := wsUpgrader.Upgrade(c.Writer, c.Request, nil)
+	upgrader := h.getWSUpgrader()
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
 		log.Error().Err(err).Str("id", id).Msg("WebSocket upgrade failed")
 		return

--- a/internal/backup/worker.go
+++ b/internal/backup/worker.go
@@ -61,8 +61,9 @@ func (w *Worker) Run(ctx context.Context) {
 
 func (w *Worker) doBackup() {
 	filename := filepath.Join(w.backupDir, fmt.Sprintf("badger_backup_%s.bak", time.Now().Format("2006-01-02_15-04-05")))
+	cleanFilename := filepath.Clean(filename)
 	
-	f, err := os.Create(filepath.Clean(filename)) // #nosec G304
+	f, err := os.OpenFile(cleanFilename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600) // #nosec G304
 	if err != nil {
 		log.Error().Err(err).Str("file", filename).Msg("Failed to create backup file")
 		return

--- a/pkg/auth/local.go
+++ b/pkg/auth/local.go
@@ -122,14 +122,12 @@ func (a *LocalAuthenticator) Login(c *gin.Context) {
 func (a *LocalAuthenticator) Middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeader := c.GetHeader("Authorization")
-		tokenString := ""
-
-		if authHeader != "" && strings.HasPrefix(authHeader, "Bearer ") {
-			tokenString = strings.TrimPrefix(authHeader, "Bearer ")
-		} else {
-			tokenString = c.Query("token")
+		if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+			return
 		}
 
+		tokenString := strings.TrimPrefix(authHeader, "Bearer ")
 		if tokenString == "" {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 			return
@@ -202,9 +200,12 @@ func RequireRole(allowedRoles ...models.Role) gin.HandlerFunc {
 
 // GenerateStreamToken создает короткоживущий токен для доступа к потоку камеры
 func (a *LocalAuthenticator) GenerateStreamToken(cameraID string) (string, error) {
+	now := time.Now()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"stream_id": cameraID,
-		"exp":       time.Now().Add(time.Second * 60).Unix(), // 60 секунд
+		"iat":       now.Unix(),
+		"nbf":       now.Unix(),
+		"exp":       now.Add(time.Second * 60).Unix(), // 60 секунд
 	})
 	return token.SignedString([]byte(a.cfg.Auth.Secret))
 }

--- a/pkg/auth/local_test.go
+++ b/pkg/auth/local_test.go
@@ -162,13 +162,13 @@ func TestLocalAuthenticator_Middleware(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
 
-	t.Run("valid token in query param", func(t *testing.T) {
+	t.Run("reject token in query param", func(t *testing.T) {
 		tok := makeToken("viewer1", models.RoleViewer, time.Hour)
 		req := httptest.NewRequest(http.MethodGet, "/api/protected?token="+tok, nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
 	})
 
 	t.Run("missing token", func(t *testing.T) {
@@ -303,5 +303,18 @@ func TestLocalAuthenticator_StreamMiddleware(t *testing.T) {
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("stream token claims contains iat and nbf", func(t *testing.T) {
+		token, err := jwt.Parse(tokCam1, func(_ *jwt.Token) (interface{}, error) {
+			return []byte(auth.cfg.Auth.Secret), nil
+		})
+		require.NoError(t, err)
+		claims, ok := token.Claims.(jwt.MapClaims)
+		require.True(t, ok)
+		assert.Equal(t, "cam-1", claims["stream_id"])
+		assert.NotNil(t, claims["iat"])
+		assert.NotNil(t, claims["nbf"])
+		assert.NotNil(t, claims["exp"])
 	})
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -132,9 +133,12 @@ func Load(path string) (*Config, error) {
 	// Генерируем JWT Secret, если его нет
 	if cfg.Auth.Secret == "" {
 		bytes := make([]byte, 32)
-		if _, err := rand.Read(bytes); err == nil {
-			cfg.Auth.Secret = hex.EncodeToString(bytes)
-			_ = cfg.Save(path)
+		if _, err := rand.Read(bytes); err != nil {
+			return nil, fmt.Errorf("generate random JWT secret: %w", err)
+		}
+		cfg.Auth.Secret = hex.EncodeToString(bytes)
+		if err := cfg.Save(path); err != nil {
+			return nil, fmt.Errorf("persist generated JWT secret: %w", err)
 		}
 	}
 
@@ -151,9 +155,10 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
-// Save сохраняет текущую конфигурацию в файл.
+// Save сохраняет текущую конфигурацию в файл с правами 0600.
 func (c *Config) Save(path string) error {
-	file, err := os.Create(filepath.Clean(path)) // #nosec G304
+	cleanPath := filepath.Clean(path)
+	file, err := os.OpenFile(cleanPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600) // #nosec G304
 	if err != nil {
 		return err
 	}
@@ -161,5 +166,9 @@ func (c *Config) Save(path string) error {
 
 	encoder := yaml.NewEncoder(file)
 	defer encoder.Close()
-	return encoder.Encode(c)
+	if err := encoder.Encode(c); err != nil {
+		return err
+	}
+	_ = os.Chmod(cleanPath, 0600)
+	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,7 +17,7 @@ server:
 auth:
   secret: "test_secret"
 `
-	err := os.WriteFile(configPath, []byte(initialYaml), 0644)
+	err := os.WriteFile(configPath, []byte(initialYaml), 0600)
 	if err != nil {
 		t.Fatalf("failed to write dummy config: %v", err)
 	}
@@ -31,8 +31,14 @@ auth:
 	if cfg.Server.Port != 8080 {
 		t.Errorf("expected port 8080, got %d", cfg.Server.Port)
 	}
-	if cfg.Auth.Secret == "" {
-		t.Errorf("Load() should generate JWT secret if missing")
+	if cfg.Auth.Secret != "test_secret" {
+		t.Errorf("expected secret test_secret, got %s", cfg.Auth.Secret)
+	}
+	if cfg.Server.GCPercent != 50 {
+		t.Errorf("expected default GCPercent 50, got %d", cfg.Server.GCPercent)
+	}
+	if cfg.Server.GRPC.Port != 50051 {
+		t.Errorf("expected default GRPC.Port 50051, got %d", cfg.Server.GRPC.Port)
 	}
 
 	// Modify and save
@@ -53,5 +59,65 @@ auth:
 	}
 	if cfg2.Auth.Secret != cfg.Auth.Secret {
 		t.Errorf("expected JWT secret to be preserved, got %s vs %s", cfg2.Auth.Secret, cfg.Auth.Secret)
+	}
+}
+
+func TestLoad_GenerateSecret(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "empty_secret.yml")
+
+	initialYaml := `
+server:
+  port: 8080
+`
+	err := os.WriteFile(configPath, []byte(initialYaml), 0600)
+	if err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if cfg.Auth.Secret == "" {
+		t.Errorf("expected generated secret, got empty")
+	}
+
+	// Verify it was persisted to disk
+	cfgReload, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+	if cfgReload.Auth.Secret != cfg.Auth.Secret {
+		t.Errorf("expected persisted secret %s, got %s", cfg.Auth.Secret, cfgReload.Auth.Secret)
+	}
+}
+
+func TestLoad_Errors(t *testing.T) {
+	t.Run("non-existent file", func(t *testing.T) {
+		_, err := Load("non_existent_file_12345.yml")
+		if err == nil {
+			t.Errorf("expected error for non-existent file")
+		}
+	})
+
+	t.Run("invalid yaml", func(t *testing.T) {
+		tempDir := t.TempDir()
+		invalidPath := filepath.Join(tempDir, "invalid.yml")
+		_ = os.WriteFile(invalidPath, []byte("server: [unclosed"), 0600)
+
+		_, err := Load(invalidPath)
+		if err == nil {
+			t.Errorf("expected error for invalid yaml")
+		}
+	})
+}
+
+func TestSave_Error(t *testing.T) {
+	cfg := &Config{}
+	err := cfg.Save("/non_existent_dir_12345/sub/config.yml")
+	if err == nil {
+		t.Errorf("expected error when saving to invalid directory")
 	}
 }


### PR DESCRIPTION
## Description

Part of #62 (Phase 1: Security Hardening & Input Boundaries).

This pull request implements comprehensive security hardening around file persistence permissions, backup import boundaries, WebSocket origin validation, and JWT token exposure minimization.

---

### Key Changes

1. **Config File Permissions & Error Handling (`pkg/config/config.go`)**
   - Modified `Save(path string)` to create `config.yaml` with restrictive `0600` permissions (`os.OpenFile(..., 0600)` + `os.Chmod`).
   - Handled errors on `cfg.Save(path)` during automatic JWT secret generation in `Load()`.

2. **Native Database Backup Permissions (`internal/backup/worker.go`)**
   - Updated `doBackup()` to create BadgerDB native backups (`.bak`) with explicit `0600` permissions.

3. **Backup Import Boundaries & Safe Reading (`internal/api/handler.go`)**
   - Added `maxBackupSize = 50 << 20` (50 MB) boundary in `ImportBackupJSON` to reject oversized payload attempts.
   - Replaced unbounded `f.Read()` with `io.ReadAll(io.LimitReader(f, maxBackupSize))` to prevent partial reads and OOM conditions.

4. **WebSocket Origin Validation (`internal/api/ws.go`)**
   - Implemented `checkWSOrigin(r *http.Request) bool` in `Handler`.
   - Validates client `Origin` against `cfg.Server.CORSAllowedOrigins` while allowing non-browser clients (empty `Origin`), wildcard `*`, and explicit allowed origins.

5. **Token Exposure Minimization & Stream Claims (`pkg/auth/local.go`)**
   - Strictly enforced `Authorization: Bearer <token>` in `auth.Middleware()` for main API routes (`/api/*`). URL query tokens (`?token=...`) are now rejected on main API endpoints to prevent token exposure in access logs and referrer headers.
   - Added standard RFC 7519 claims (`iat`, `nbf`) to short-lived camera stream tokens in `GenerateStreamToken(cameraID)`.

---

### Verification

- Unit & integration tests pass cleanly: `go test -count=1 ./...`
- Linter check: `golangci-lint run ./...` (0 issues)
- Security scan: `gosec` (46 files, 10090 lines, 0 issues)
