### PR TITLE
feat(webrtc): Phase 2 — dynamic frame duration pacing & buffer parameter ownership (#62)

### DIFF
--- a/internal/buffer/ring.go
+++ b/internal/buffer/ring.go
@@ -86,13 +86,22 @@ func (rb *RingBuffer) Write(f *Frame) {
 	}
 }
 
-// SetParams сохраняет параметры кодека (VPS, SPS, PPS).
+func cloneBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	c := make([]byte, len(b))
+	copy(c, b)
+	return c
+}
+
+// SetParams сохраняет параметры кодека (VPS, SPS, PPS), создавая защитные копии срезов.
 func (rb *RingBuffer) SetParams(vps, sps, pps []byte) {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
-	rb.vps = vps
-	rb.sps = sps
-	rb.pps = pps
+	rb.vps = cloneBytes(vps)
+	rb.sps = cloneBytes(sps)
+	rb.pps = cloneBytes(pps)
 }
 
 // Close закрывает буфер и каналы всех читателей.
@@ -107,11 +116,11 @@ func (rb *RingBuffer) Close() {
 	}
 }
 
-// GetParams возвращает текущие параметры кодека (VPS, SPS, PPS).
+// GetParams возвращает защитные копии текущих параметров кодека (VPS, SPS, PPS).
 func (rb *RingBuffer) GetParams() ([]byte, []byte, []byte) {
 	rb.mu.RLock()
 	defer rb.mu.RUnlock()
-	return rb.vps, rb.sps, rb.pps
+	return cloneBytes(rb.vps), cloneBytes(rb.sps), cloneBytes(rb.pps)
 }
 
 // Reader предоставляет интерфейс для чтения из RingBuffer через неблокирующий канал.

--- a/internal/buffer/ring_test.go
+++ b/internal/buffer/ring_test.go
@@ -356,4 +356,43 @@ func TestRingBuffer_DefensiveCapacityGuard(t *testing.T) {
 	}
 }
 
+func TestRingBuffer_ParamsCloning(t *testing.T) {
+	rb := NewRingBuffer(10)
+	defer rb.Close()
+
+	vps := []byte{0x01, 0x02}
+	sps := []byte{0x03, 0x04}
+	pps := []byte{0x05, 0x06}
+
+	rb.SetParams(vps, sps, pps)
+
+	// 1. Mutate original caller slices; buffer should NOT be affected
+	vps[0] = 0xFF
+	sps[0] = 0xFF
+	pps[0] = 0xFF
+
+	outVps, outSps, outPps := rb.GetParams()
+	if outVps[0] != 0x01 || outSps[0] != 0x03 || outPps[0] != 0x05 {
+		t.Errorf("SetParams did not defensively clone: got vps=%v, sps=%v, pps=%v", outVps, outSps, outPps)
+	}
+
+	// 2. Mutate returned slices; buffer should NOT be affected
+	outVps[0] = 0xAA
+	outSps[0] = 0xAA
+	outPps[0] = 0xAA
+
+	outVps2, outSps2, outPps2 := rb.GetParams()
+	if outVps2[0] != 0x01 || outSps2[0] != 0x03 || outPps2[0] != 0x05 {
+		t.Errorf("GetParams did not defensively clone: got vps=%v, sps=%v, pps=%v", outVps2, outSps2, outPps2)
+	}
+
+	// 3. Test nil params
+	rb.SetParams(nil, nil, nil)
+	nilVps, nilSps, nilPps := rb.GetParams()
+	if nilVps != nil || nilSps != nil || nilPps != nil {
+		t.Errorf("expected nil params, got %v, %v, %v", nilVps, nilSps, nilPps)
+	}
+}
+
+
 

--- a/internal/webrtc/muxer.go
+++ b/internal/webrtc/muxer.go
@@ -213,6 +213,28 @@ func (h *WHEPHandler) pumpMetadata(ctx context.Context, dc *webrtc.DataChannel) 
 	}
 }
 
+const (
+	defaultFrameDuration = 40 * time.Millisecond // 25 FPS fallback
+	minFrameDuration     = time.Millisecond          // 1000 FPS upper bound
+	maxFrameDuration     = time.Second              // 1 FPS lower bound / gap clamp
+)
+
+// calculateFrameDuration computes dynamic frame duration from PTS delta with safety clamping.
+func calculateFrameDuration(currentPTS time.Duration, lastPTS time.Duration, hasLastPTS bool) (time.Duration, time.Duration, bool) {
+	if !hasLastPTS {
+		return defaultFrameDuration, currentPTS, true
+	}
+	delta := currentPTS - lastPTS
+	if delta <= 0 || delta > maxFrameDuration {
+		// Clock reset, backward jump, reconnect, or excessive gap: fallback to safe default
+		return defaultFrameDuration, currentPTS, true
+	}
+	if delta < minFrameDuration {
+		delta = minFrameDuration
+	}
+	return delta, currentPTS, true
+}
+
 func (h *WHEPHandler) pumpFrames(ctx context.Context, pc *webrtc.PeerConnection, track *webrtc.TrackLocalStaticSample) {
 	reader := h.rb.NewReader()
 	defer reader.Close()
@@ -221,11 +243,17 @@ func (h *WHEPHandler) pumpFrames(ctx context.Context, pc *webrtc.PeerConnection,
 	// Wait for the first keyframe to send SPS/PPS inline if needed
 	_, sps, pps := h.rb.GetParams()
 
+	var lastPTS time.Duration
+	var hasLastPTS bool
+
 	for {
 		frame, err := reader.ReadContext(ctx)
 		if err != nil || frame == nil {
 			return
 		}
+
+		var duration time.Duration
+		duration, lastPTS, hasLastPTS = calculateFrameDuration(frame.Timestamp, lastPTS, hasLastPTS)
 
 		annexB := make([]byte, 0, 1024*100) // pre-allocate
 		
@@ -248,7 +276,7 @@ func (h *WHEPHandler) pumpFrames(ctx context.Context, pc *webrtc.PeerConnection,
 
 		if writeErr := track.WriteSample(media.Sample{
 			Data:     annexB,
-			Duration: time.Second / 25, // Assume 25fps for playback pacing
+			Duration: duration,
 		}); writeErr != nil {
 			log.Error().Err(writeErr).Str("stream", h.streamID).Msg("WebRTC track write error")
 			return

--- a/internal/webrtc/muxer_test.go
+++ b/internal/webrtc/muxer_test.go
@@ -122,3 +122,112 @@ func TestWHEPHandler_MetadataDataChannel(t *testing.T) {
 		t.Fatal("timeout waiting for metadata message on DataChannel")
 	}
 }
+
+func TestCalculateFrameDuration(t *testing.T) {
+	tests := []struct {
+		name             string
+		currentPTS       time.Duration
+		lastPTS          time.Duration
+		hasLastPTS       bool
+		expectedDuration time.Duration
+		expectedNewLast  time.Duration
+		expectedHasPTS   bool
+	}{
+		{
+			name:             "first frame fallback",
+			currentPTS:       100 * time.Millisecond,
+			lastPTS:          0,
+			hasLastPTS:       false,
+			expectedDuration: 40 * time.Millisecond,
+			expectedNewLast:  100 * time.Millisecond,
+			expectedHasPTS:   true,
+		},
+		{
+			name:             "steady 25 FPS pacing (40ms)",
+			currentPTS:       140 * time.Millisecond,
+			lastPTS:          100 * time.Millisecond,
+			hasLastPTS:       true,
+			expectedDuration: 40 * time.Millisecond,
+			expectedNewLast:  140 * time.Millisecond,
+			expectedHasPTS:   true,
+		},
+		{
+			name:             "steady 30 FPS pacing (33ms)",
+			currentPTS:       133 * time.Millisecond,
+			lastPTS:          100 * time.Millisecond,
+			hasLastPTS:       true,
+			expectedDuration: 33 * time.Millisecond,
+			expectedNewLast:  133 * time.Millisecond,
+			expectedHasPTS:   true,
+		},
+		{
+			name:             "steady 60 FPS pacing (16ms)",
+			currentPTS:       116 * time.Millisecond,
+			lastPTS:          100 * time.Millisecond,
+			hasLastPTS:       true,
+			expectedDuration: 16 * time.Millisecond,
+			expectedNewLast:  116 * time.Millisecond,
+			expectedHasPTS:   true,
+		},
+		{
+			name:             "steady 15 FPS pacing (66ms)",
+			currentPTS:       166 * time.Millisecond,
+			lastPTS:          100 * time.Millisecond,
+			hasLastPTS:       true,
+			expectedDuration: 66 * time.Millisecond,
+			expectedNewLast:  166 * time.Millisecond,
+			expectedHasPTS:   true,
+		},
+		{
+			name:             "sub-millisecond delta clamped to minFrameDuration (1ms)",
+			currentPTS:       100*time.Millisecond + 200*time.Microsecond,
+			lastPTS:          100 * time.Millisecond,
+			hasLastPTS:       true,
+			expectedDuration: time.Millisecond,
+			expectedNewLast:  100*time.Millisecond + 200*time.Microsecond,
+			expectedHasPTS:   true,
+		},
+		{
+			name:             "backward jump / timestamp reset recovers with fallback",
+			currentPTS:       50 * time.Millisecond,
+			lastPTS:          500 * time.Millisecond,
+			hasLastPTS:       true,
+			expectedDuration: 40 * time.Millisecond,
+			expectedNewLast:  50 * time.Millisecond,
+			expectedHasPTS:   true,
+		},
+		{
+			name:             "zero delta duplicate frame recovers with fallback",
+			currentPTS:       500 * time.Millisecond,
+			lastPTS:          500 * time.Millisecond,
+			hasLastPTS:       true,
+			expectedDuration: 40 * time.Millisecond,
+			expectedNewLast:  500 * time.Millisecond,
+			expectedHasPTS:   true,
+		},
+		{
+			name:             "excessive gap (>1s stall) clamped to fallback",
+			currentPTS:       6 * time.Second,
+			lastPTS:          1 * time.Second,
+			hasLastPTS:       true,
+			expectedDuration: 40 * time.Millisecond,
+			expectedNewLast:  6 * time.Second,
+			expectedHasPTS:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dur, newLast, hasPTS := calculateFrameDuration(tt.currentPTS, tt.lastPTS, tt.hasLastPTS)
+			if dur != tt.expectedDuration {
+				t.Errorf("duration: expected %v, got %v", tt.expectedDuration, dur)
+			}
+			if newLast != tt.expectedNewLast {
+				t.Errorf("newLastPTS: expected %v, got %v", tt.expectedNewLast, newLast)
+			}
+			if hasPTS != tt.expectedHasPTS {
+				t.Errorf("hasPTS: expected %v, got %v", tt.expectedHasPTS, hasPTS)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Part of #62 (Phase 2: Core Media Pipeline & WebRTC Timing Correctness).

This pull request implements dynamic frame duration calculation and pacing for WebRTC (WHEP) streaming and enforces defensive parameter cloning in the frame buffer.

---

### Key Changes

1. **Dynamic WebRTC Frame Duration & Playback Pacing (`internal/webrtc/muxer.go`)**
   - Replaced fixed `time.Second / 25` assumption with dynamic `Duration` calculation computed from incoming PTS deltas (`pts - lastPTS`).
   - Implemented `calculateFrameDuration` helper with safety boundaries:
     - First-frame baseline initialization (default `40ms` fallback).
     - Backward timestamp jumps / RTSP clock resets / reconnect handling (resets baseline and falls back to safe `40ms`).
     - Clamping valid sample durations to `[1ms, 1000ms]` (supports 1 FPS to 1000 FPS).
     - Network stall / excessive gap clamp (>1s gap resets baseline to prevent player stalls).

2. **Buffer Parameter Ownership & Isolation (`internal/buffer/ring.go`)**
   - Added `cloneBytes()` helper to defensively copy SPS, PPS, and VPS slices in `RingBuffer.SetParams()` and `RingBuffer.GetParams()`.
   - Protects against cross-goroutine mutation and slice corruption during RTSP reconnection.

3. **Comprehensive Unit Tests**
   - `internal/webrtc/muxer_test.go`: Added `TestCalculateFrameDuration` covering 15, 25, 30, 60 FPS, sub-millisecond deltas, backward jumps, duplicate timestamps, and gap clamping.
   - `internal/buffer/ring_test.go`: Added `TestRingBuffer_ParamsCloning` verifying slice isolation and `nil` handling.

---

### Verification
- `go test -count=1 ./...`: Passed
- `golangci-lint run ./...`: 0 issues
- `gosec`: 0 issues (46 files, 10127 lines scanned)
- `scripts/check_coverage.go`: 100% PASS across all critical subsystems
