### PR TITLE
feat(concurrency): Phase 3 — lock scope optimization, goroutine draining & lifecycle management (#62)

### DIFF
--- a/internal/backup/worker.go
+++ b/internal/backup/worker.go
@@ -44,15 +44,16 @@ func (w *Worker) Run(ctx context.Context) {
 	ticker := time.NewTicker(w.interval)
 	defer ticker.Stop()
 
-	// Делаем первый бэкап при старте (с небольшой задержкой)
-	time.AfterFunc(5*time.Minute, func() {
-		w.doBackup()
-	})
+	// Делаем первый бэкап при старте (с небольшой задержкой, управляемой контекстом)
+	initialTimer := time.NewTimer(5 * time.Minute)
+	defer initialTimer.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-initialTimer.C:
+			w.doBackup()
 		case <-ticker.C:
 			w.doBackup()
 		}

--- a/internal/stream/manager.go
+++ b/internal/stream/manager.go
@@ -51,14 +51,19 @@ func (m *Manager) AddStream(id, url string, record bool, lazyHLS bool, transport
 	return nil
 }
 
-// RemoveStream останавливает и удаляет поток.
+// RemoveStream останавливает и удаляет поток без удержания блокировки менеджера во время Stop().
 func (m *Manager) RemoveStream(id string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	var toStop *Stream
 
+	m.mu.Lock()
 	if st, ok := m.streams[id]; ok {
-		st.Stop()
 		delete(m.streams, id)
+		toStop = st
+	}
+	m.mu.Unlock()
+
+	if toStop != nil {
+		toStop.Stop()
 	}
 }
 
@@ -92,38 +97,42 @@ func (m *Manager) HasStream(id string) bool {
 }
 
 // UpsertStream атомарно создает, обновляет или останавливает поток в зависимости от конфигурации.
-// Если поток отключен (disabled=true), он останавливается и удаляется из менеджера.
-// Если поток включен (disabled=false), он создается или обновляется при изменении параметров.
+// Остановка старого потока вынесена за пределы блокировки менеджера.
 func (m *Manager) UpsertStream(id, url string, record bool, lazyHLS bool, transport string, disabled bool) {
+	var toStop *Stream
+	var newStream *Stream
+
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	existing, exists := m.streams[id]
-	if disabled {
+	switch {
+	case disabled:
 		if exists {
-			existing.Stop()
 			delete(m.streams, id)
+			toStop = existing
+		}
+	case exists:
+		if !existing.MatchesConfig(url, record, lazyHLS, transport) {
+			toStop = existing
+			newStream = NewStream(id, url, record, lazyHLS, transport)
+			m.streams[id] = newStream
+		}
+	default:
+		newStream = NewStream(id, url, record, lazyHLS, transport)
+		m.streams[id] = newStream
+	}
+	m.mu.Unlock()
+
+	if toStop != nil {
+		toStop.Stop()
+		if disabled {
 			log.Info().Str("id", id).Msg("Stream stopped and removed (disabled)")
+		} else {
+			log.Info().Str("id", id).Msg("Stream parameters changed, recreating stream")
 		}
-		return
 	}
-
-	if exists {
-		if existing.MatchesConfig(url, record, lazyHLS, transport) {
-			// Параметры стрима не изменились, оставляем работать без прерывания
-			return
-		}
-		// Параметры изменились, пересоздаем стрим
-		existing.Stop()
-		delete(m.streams, id)
-		log.Info().Str("id", id).Msg("Stream parameters changed, recreating stream")
-	}
-
-	st := NewStream(id, url, record, lazyHLS, transport)
-	m.streams[id] = st
 }
 
-// SyncWithStorage синхронизирует состояние потоков с базой.
+// SyncWithStorage синхронизирует состояние потоков с базой без удержания блокировки во время остановок.
 func (m *Manager) SyncWithStorage(store registry.StateStore) error {
 	log.Info().Msg("Syncing stream manager with storage...")
 	
@@ -132,16 +141,16 @@ func (m *Manager) SyncWithStorage(store registry.StateStore) error {
 		return err
 	}
 	
+	var toStop []*Stream
+
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	
 	activeIDs := make(map[string]struct{}, len(cams))
 	for _, cam := range cams {
 		if !cam.Disabled {
 			activeIDs[cam.ID] = struct{}{}
 			if existing, exists := m.streams[cam.ID]; exists {
 				if !existing.MatchesConfig(cam.URL, cam.Record, cam.LazyHLS, cam.Transport) {
-					existing.Stop()
+					toStop = append(toStop, existing)
 					m.streams[cam.ID] = NewStream(cam.ID, cam.URL, cam.Record, cam.LazyHLS, cam.Transport)
 				}
 			} else {
@@ -156,11 +165,32 @@ func (m *Manager) SyncWithStorage(store registry.StateStore) error {
 	// Остановка потоков, которых больше нет в активном списке
 	for id, st := range m.streams {
 		if _, ok := activeIDs[id]; !ok {
-			st.Stop()
+			toStop = append(toStop, st)
 			delete(m.streams, id)
-			log.Info().Str("id", id).Msg("Stream stopped (removed or disabled in storage)")
+			log.Info().Str("id", id).Msg("Stream marked for stop (removed or disabled in storage)")
 		}
+	}
+	m.mu.Unlock()
+
+	// Останавливаем потоки вне блокировки менеджера
+	for _, st := range toStop {
+		st.Stop()
 	}
 	
 	return nil
+}
+
+// Close останавливает все зарегистрированные потоки.
+func (m *Manager) Close() {
+	m.mu.Lock()
+	all := make([]*Stream, 0, len(m.streams))
+	for id, st := range m.streams {
+		all = append(all, st)
+		delete(m.streams, id)
+	}
+	m.mu.Unlock()
+
+	for _, st := range all {
+		st.Stop()
+	}
 }

--- a/internal/stream/manager_test.go
+++ b/internal/stream/manager_test.go
@@ -336,3 +336,43 @@ func TestManager_Concurrent_EditVsDelete_NoResurrection(t *testing.T) {
 		}
 	}
 }
+
+func TestManager_Close_StopsAllStreams(t *testing.T) {
+	m := NewManager()
+	for i := 0; i < 10; i++ {
+		_ = m.AddStream(fmt.Sprintf("cam_close_%d", i), "synthetic://", false, true, "tcp")
+	}
+
+	if len(m.GetStreams()) != 10 {
+		t.Fatalf("expected 10 streams before Close()")
+	}
+
+	m.Close()
+
+	if len(m.GetStreams()) != 0 {
+		t.Fatalf("expected 0 streams after Close(), got %d", len(m.GetStreams()))
+	}
+}
+
+func TestManager_RemoveStream_NonBlockingGet(_ *testing.T) {
+	m := NewManager()
+	_ = m.AddStream("cam_slow", "synthetic://", false, true, "tcp")
+	_ = m.AddStream("cam_fast", "synthetic://", false, true, "tcp")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		m.RemoveStream("cam_slow")
+	}()
+
+	// Parallel reader should immediately be able to query cam_fast without lock contention
+	for i := 0; i < 20; i++ {
+		_, _ = m.GetStream("cam_fast")
+		_ = m.GetStreams()
+	}
+
+	wg.Wait()
+	m.Close()
+}
+

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -66,6 +66,9 @@ type Stream struct {
 
 	currentBitrate atomic.Uint64
 	isDegraded     atomic.Bool
+
+	stopOnce sync.Once
+	wg       sync.WaitGroup
 }
 
 // NewStream создает и запускает поток.
@@ -93,7 +96,11 @@ func NewStream(id, url string, record bool, lazyHLS bool, transport string) *Str
 		sub := s.metaBroadcaster.Subscribe()
 		s.hlsMuxer = hls.NewMuxer(id, rb, sub.C, func() { s.metaBroadcaster.Unsubscribe(sub) })
 	} else {
-		go s.lazyHLSWatchdog()
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.lazyHLSWatchdog()
+		}()
 	}
 
 	if record {
@@ -102,8 +109,17 @@ func NewStream(id, url string, record bool, lazyHLS bool, transport string) *Str
 		})
 	}
 
-	go s.bitrateTask()
-	go s.run()
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.bitrateTask()
+	}()
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.run()
+	}()
 
 	return s
 }
@@ -254,27 +270,32 @@ func (s *Stream) run() {
 	}
 }
 
-// Stop останавливает работу потока.
+// Stop останавливает работу потока, ожидает завершения всех фоновых воркеров.
+// Метод является идемпотентным (защищен через sync.Once).
 func (s *Stream) Stop() {
-	s.cancelCtx()
-	
-	s.rtspMu.Lock()
-	if s.rtspClient != nil {
-		s.rtspClient.Close()
-	}
-	s.rtspMu.Unlock()
+	s.stopOnce.Do(func() {
+		s.cancelCtx()
+		
+		s.rtspMu.Lock()
+		if s.rtspClient != nil {
+			s.rtspClient.Close()
+		}
+		s.rtspMu.Unlock()
 
-	s.ringBuffer.Close()
-	
-	s.muxerMu.Lock()
-	if s.hlsMuxer != nil {
-		s.hlsMuxer.Stop()
-	}
-	s.muxerMu.Unlock()
-	
-	if s.mp4Recorder != nil {
-		s.mp4Recorder.Stop()
-	}
+		s.ringBuffer.Close()
+		
+		s.muxerMu.Lock()
+		if s.hlsMuxer != nil {
+			s.hlsMuxer.Stop()
+		}
+		s.muxerMu.Unlock()
+		
+		if s.mp4Recorder != nil {
+			s.mp4Recorder.Stop()
+		}
+
+		s.wg.Wait()
+	})
 }
 
 // PipelineConfig определяет параметры, управляющие жизненным циклом и поведением рантайм-пайплайна.

--- a/internal/stream/stream_test.go
+++ b/internal/stream/stream_test.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -112,3 +113,24 @@ func TestStream_StateAndStats(t *testing.T) {
 		t.Errorf("expected 10 reconnects, got %d", stats.Reconnects)
 	}
 }
+
+func TestStream_Stop_Idempotent(t *testing.T) {
+	s := NewStream("cam_idempotent", "synthetic://", false, true, "tcp")
+	
+	// Calling Stop multiple times concurrently or sequentially should never panic or hang
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.Stop()
+		}()
+	}
+	wg.Wait()
+
+	// Context should be cancelled
+	if s.ctx.Err() == nil {
+		t.Errorf("expected context to be cancelled after Stop()")
+	}
+}
+

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -101,13 +101,15 @@ func Run(cfg *config.Config) {
 	router := api.SetupRouter(handler, registry.CurrentAuthenticator, cfg.Server.Debug, cfg.Server.CORSAllowedOrigins)
 
 	// 6. Запуск сервера с Graceful Shutdown
+	// WriteTimeout установлен в 0 (отключен глобальный жесткий таймаут), чтобы поддерживать
+	// долгоживущие SSE-потоки логов (/api/logs/stream) и выгрузку больших fMP4 архивов без обрыва сокета.
 	addr := fmt.Sprintf(":%d", cfg.Server.Port)
 	srv := &http.Server{
 		Addr:              addr,
 		Handler:           router,
 		ReadHeaderTimeout: 10 * time.Second,
-		WriteTimeout:      15 * time.Second,
-		IdleTimeout:       60 * time.Second,
+		WriteTimeout:      0,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	go func() {
@@ -160,7 +162,10 @@ func Run(cfg *config.Config) {
 	<-quit
 	log.Info().Msg("Shutting down server...")
 
-	// Даем 5 секунд на корректное завершение текущих соединений
+	// Останавливаем фоновые контекстные задачи
+	cancelAll()
+
+	// Даем 5 секунд на корректное завершение текущих HTTP соединений
 	ctxShutdown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -170,10 +175,8 @@ func Run(cfg *config.Config) {
 
 	grpcServer.Stop()
 
-	// Останавливаем потоки и менеджеры (опционально, если есть метод)
-	for _, st := range manager.GetStreams() {
-		manager.RemoveStream(st.ID)
-	}
+	// Останавливаем все медиа-потоки
+	manager.Close()
 
 	log.Info().Msg("Server exiting")
 }


### PR DESCRIPTION
## Description

Part of #62 (Phase 3: Concurrency, Locks & Lifecycle Management).

This pull request optimizes lock scopes in the stream manager to eliminate read starvation, guarantees clean goroutine draining and idempotent stream shutdown via `sync.WaitGroup` and `sync.Once`, secures the backup worker timer against orphaned execution, and adjusts HTTP server timeouts for streaming stability.

---

### Key Changes

1. **Stream Manager Lock Scope Optimization (`internal/stream/manager.go`)**
   - Decoupled `Stream.Stop()` from `m.mu.Lock()` across `RemoveStream`, `UpsertStream`, and `SyncWithStorage`.
   - `m.mu.Lock()` now only guards rapid in-memory map mutations (`m.streams`), releasing mutex prior to invoking stream teardown.
   - Added `Manager.Close()` for stopping all streams cleanly.

2. **Stream Worker Goroutine Draining & Idempotent Shutdown (`internal/stream/stream.go`)**
   - Added `sync.WaitGroup` to track all worker loops (`run()`, `bitrateTask()`, and `lazyHLSWatchdog()`).
   - Wrapped `Stream.Stop()` in `sync.Once` and added `s.wg.Wait()` to eliminate orphan goroutines and race conditions on rapid restart.

3. **Context-Aware Backup Worker Timer (`internal/backup/worker.go`)**
   - Replaced detached `time.AfterFunc` with a context-bound `time.NewTimer` and `defer initialTimer.Stop()`, guaranteeing cancellation on engine shutdown.

4. **HTTP Server Streaming & Graceful Shutdown (`pkg/engine/engine.go`)**
   - Set `WriteTimeout: 0` (unbounded response streaming with `ReadHeaderTimeout: 10s` and `IdleTimeout: 120s`) to support persistent SSE log streams (`/api/logs/stream`) and large fMP4 exports without premature socket disconnection.
   - Wired context cancellation and `manager.Close()` into graceful shutdown sequence.

5. **Unit Tests**
   - `internal/stream/manager_test.go`: Added `TestManager_Close_StopsAllStreams` and `TestManager_RemoveStream_NonBlockingGet`.
   - `internal/stream/stream_test.go`: Added `TestStream_Stop_Idempotent`.

---

### Verification
- `go test -count=1 ./...`: Passed
- `golangci-lint run ./...`: 0 issues
- `gosec`: 0 issues (46 files, 10182 lines scanned)
- `scripts/check_coverage.go`: 100% PASS across all critical subsystems
