### PR TITLE
feat(eventbus): Phase 5 — deterministic shutdown, queue draining & fault recovery semantics (#62)

### DIFF
--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -114,6 +114,9 @@ func (r *Recorder) run() {
 	defer func() {
 		if err := recover(); err != nil {
 			log.Error().Interface("panic", err).Str("streamID", r.streamID).Msg("Recovered from panic in Recorder.run")
+			if r.onDegraded != nil {
+				r.onDegraded(true)
+			}
 			finalizeFailure()
 		}
 	}()

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -157,6 +158,9 @@ func (s *Stream) run() {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Error().Interface("panic", r).Str("id", s.ID).Msg("Recovered from panic in Stream.run")
+			s.state.Store(models.StateOffline)
+			s.lastError.Store(fmt.Sprintf("panic: %v", r))
+			s.isDegraded.Store(true)
 		}
 	}()
 

--- a/pkg/eventbus/eventbus.go
+++ b/pkg/eventbus/eventbus.go
@@ -5,6 +5,7 @@ import (
 	"hash/fnv"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/RUSEGAL/ruseon-core/pkg/config"
@@ -32,7 +33,10 @@ type EventBus struct {
 	workers         []chan Event
 	circuitBreakers map[string]time.Time // Общий Circuit Breaker для всех воркеров (URL -> время разблокировки)
 	wg              sync.WaitGroup
-	// quit канал убран в пользу закрытия каналов workers
+
+	stopMu   sync.RWMutex
+	stopped  atomic.Bool
+	stopOnce sync.Once
 }
 
 // New создает новую шину событий и запускает воркеры.
@@ -57,14 +61,16 @@ func New(cfg config.EventsConfig, numWorkers int) Bus {
 }
 
 func (b *EventBus) Publish(topic string, cameraID string, data any) {
-	if len(b.webhooks) == 0 {
-		return // Нет смысла рассылать, если нет подписчиков
+	if b.stopped.Load() || len(b.webhooks) == 0 {
+		return // Нет смысла рассылать, если шина остановлена или нет подписчиков
 	}
 
-	// Защита от panic: send on closed channel во время Graceful Shutdown
-	defer func() {
-		_ = recover() // Канал уже закрыт (система останавливается), просто игнорируем событие
-	}()
+	b.stopMu.RLock()
+	defer b.stopMu.RUnlock()
+
+	if b.stopped.Load() {
+		return
+	}
 
 	event := Event{
 		TimestampMs: time.Now().UnixMilli(),
@@ -96,11 +102,16 @@ func (b *EventBus) Publish(topic string, cameraID string, data any) {
 }
 
 func (b *EventBus) Stop() {
-	// Закрываем каналы воркеров, чтобы они могли "доработать" оставшиеся события (Graceful Shutdown)
-	for _, ch := range b.workers {
-		close(ch)
-	}
-	b.wg.Wait()
+	b.stopOnce.Do(func() {
+		b.stopMu.Lock()
+		b.stopped.Store(true)
+		for _, ch := range b.workers {
+			close(ch)
+		}
+		b.stopMu.Unlock()
+
+		b.wg.Wait()
+	})
 }
 
 func (b *EventBus) workerLoop(_ int, ch <-chan Event) {

--- a/pkg/eventbus/eventbus_test.go
+++ b/pkg/eventbus/eventbus_test.go
@@ -196,3 +196,42 @@ func TestEventBus_WebhookEdgeCases(_ *testing.T) {
 	busInvalidURL.Stop()
 }
 
+func TestEventBus_Stop_ConcurrentAndIdempotent(_ *testing.T) {
+	cfg := config.EventsConfig{
+		Webhooks: []config.WebhookConfig{
+			{URL: "http://127.0.0.1:9999", Topics: []string{"*"}},
+		},
+	}
+	bus := New(cfg, 4)
+
+	var wg sync.WaitGroup
+
+	// 10 concurrent publishers
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				bus.Publish("topic", "cam", map[string]int{"id": id, "seq": j})
+				time.Sleep(1 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	// Concurrent Stop calls
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(10 * time.Millisecond)
+			bus.Stop()
+		}()
+	}
+
+	wg.Wait()
+
+	// Post-stop publish should not panic
+	bus.Publish("topic_post_stop", "cam", nil)
+}
+
+


### PR DESCRIPTION
## Description

Part of #62 (Phase 5: EventBus & Fault Tolerance).

This pull request establishes deterministic, zero-panic EventBus lifecycle management, guarantees graceful worker queue draining upon shutdown, and eliminates silent ingest/recording degradation on runtime panic recovery.

---

### Key Changes

1. **Deterministic EventBus Lifecycle (`pkg/eventbus/eventbus.go`)**
   - Replaced panic-recovery on closed channels with explicit atomic state `b.stopped.Load()`, `sync.RWMutex` (`stopMu`), and `sync.Once` in `Stop()`.
   - `Publish()` drops events cleanly when stopped without triggering panics.
   - `Stop()` is idempotent and guarantees all queued webhook events are processed prior to return (`b.wg.Wait()`).

2. **Component Health & Degradation on Panic Recovery (`internal/stream/stream.go`, `internal/recorder/recorder.go`)**
   - In `Stream.run`: when `recover()` catches a panic, updates camera state to `models.StateOffline`, records the error in `s.lastError`, and marks `s.isDegraded = true`.
   - In `Recorder.run`: when `recover()` catches a panic, notifies `r.onDegraded(true)` and executes `finalizeFailure()`.
   - Eliminates silent degradation where dead goroutines left cameras reported as online.

3. **Unit Tests**
   - `pkg/eventbus/eventbus_test.go`: Added `TestEventBus_Stop_ConcurrentAndIdempotent` (10 concurrent publishers vs 5 concurrent `Stop()` calls).

---

### Verification
- `go test -count=1 ./...`: Passed
- `golangci-lint run ./...`: 0 issues
- `gosec`: 0 issues (46 files, 10364 lines scanned)
- `scripts/check_coverage.go`: 100% PASS across all critical subsystems (eventbus: **93.7%**, stream: **77.5%**, recorder: **67.6%**)
